### PR TITLE
Embed built-in regex replacements into the extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,39 @@ BunnY制作，搭配Bunnyhole Lab食用。
    ```
 5. 点击确定保存
 
+## 自定义正则替换
+
+从 v4.5 起，胡萝卜扩展会在加载时读取根目录下的 `regex-rules.json`，把其中定义的规则自动作用到 SillyTavern 的对话消息与快捷插入的提示词：
+
+- `promptOnly: true` 的规则只会在插入提示词（发送文本框）时运行；
+- 其他规则会在聊天区的 `.mes_text` 消息渲染后运行，并与表情包/Unsplash 替换协同；
+- `markdownOnly`、`runOnEdit`、`minDepth`、`maxDepth` 等字段控制规则生效范围。
+
+| 字段 | 说明 |
+| --- | --- |
+| `id` | 唯一标识符，可使用在线 UUID 生成器创建。 |
+| `scriptName` | 规则名称，用于备注用途。 |
+| `findRegex` | 查找用的正则表达式，建议使用 `/.../flags` 形式。 |
+| `replaceString` | 替换后的内容，支持捕获组引用（如 `$1`）。 |
+| `trimStrings` | 预处理要移除的字符串数组（目前保留字段，可留空数组）。 |
+| `placement` | 与 SillyTavern 配置保持一致，可留作记录。 |
+| `disabled` | 设为 `true` 可临时停用规则。 |
+| `markdownOnly` | 仅对 Markdown 渲染的消息生效。 |
+| `promptOnly` | 仅在发送提示词时运行；设为 `false` 则用于聊天消息。 |
+| `runOnEdit` | 当消息被再次编辑/刷新时是否重新执行。 |
+| `substituteRegex` | 兼容字段，暂按普通字符串处理。 |
+| `minDepth` / `maxDepth` | 限制 DOM 深度（默认 `null` 表示不限制）。 |
+
+### 在 `regex-rules.json` 中添加新规则
+
+1. 使用文本编辑器打开仓库根目录下的 `regex-rules.json`。
+2. 复制现有对象（花括号包裹的部分），粘贴到数组末尾并为上一条补上逗号。
+3. 修改 `id`、`scriptName`、`findRegex`、`replaceString` 等字段为自己的需求。
+4. 根据用途调整 `promptOnly`、`markdownOnly`、`runOnEdit`、`minDepth`、`maxDepth` 等范围控制参数。
+5. 保存文件后，在 SillyTavern 中刷新页面或重载扩展即可生效；现有消息会自动重新执行正则。
+
+> 提示：若需要同时对提示词与聊天消息生效，可以创建两条规则，分别设置 `promptOnly: true` 和 `promptOnly: false`。
+
 ## 技术特性
 
 - 使用 jQuery 构建，兼容 SillyTavern 环境

--- a/regex-rules.json
+++ b/regex-rules.json
@@ -1,0 +1,36 @@
+[
+  {
+    "id": "cf01534d-e108-4684-a794-fff8bee6203f",
+    "scriptName": "来自小图-移除思维链",
+    "findRegex": "/(<thinking>[\\s\\S]*?<\\/thinking>)|(<!--[\\s\\S]*?-->)|(<details(?:\\s+close)?>\\s*<summary>IF[\\s\\S]*?<\\/details>)|(<section\\s+data-id\\s*=\\s*[\"']?(\\d+)[\"']?[^>]*>([\\s\\S]*?)<\\/section>)/g",
+    "replaceString": "",
+    "trimStrings": [],
+    "placement": [
+      2
+    ],
+    "disabled": false,
+    "markdownOnly": false,
+    "promptOnly": true,
+    "runOnEdit": true,
+    "substituteRegex": 0,
+    "minDepth": null,
+    "maxDepth": null
+  },
+  {
+    "id": "08d7874b-e7ad-4043-9729-7b18a5fb3e91",
+    "scriptName": "BHL-user气泡（水滴+头像",
+    "disabled": false,
+    "runOnEdit": true,
+    "findRegex": "/^“(.*?)”$/gm",
+    "replaceString": "<div style=\"display: flex;margin-bottom: 8px;align-items: flex-start;position: relative;animation: message-pop 0.3s ease-out;flex-direction: row-reverse;\">\n   <div class=\"B_U_avar\" style=\"width: 40px; height: 40px; flex-shrink: 0; border-radius: 50%; padding: 5px 5px; overflow: hidden; margin-left: 10px; background-image: url('https://i.postimg.cc/0NxXgWH8/640.jpg'); background-size: cover; background-position: center;\">\n </div>\n    <div style=\"padding: 10px 14px;border-radius: 24px !important;line-height: 1.4;border-bottom-right-radius: 24px !important;word-wrap: break-word;position:relative;transition: transform 0.2s;background: transparent !important;box-shadow:4px 4px 8px rgba(0, 0, 0, 0.10), -2px -2px 4px rgba(255, 255, 255, 0.3), inset 6px 6px 8px rgba(0, 0, 0, 0.10),  inset -6px -6px 8px rgba(255, 255, 255, 0.5)!important;border: 1px solid rgba(200, 200, 200,0.3) !important;\">\n    <span style=\"position: absolute;top: 5px; left: 5px;right: auto;  width: 12px;height: 6px;background: white;border-radius: 50% 50% 50% 50% / 60% 60% 40% 40%;opacity: 0.9; z-index: 2; transform: rotate(-45deg);\"></span>\n      $1\n      <span style=\"position: absolute;top: 15px; left: 5px;right: auto;  width: 4px;height: 4px;background: white;border-radius: 50%;opacity: 0.6; z-index: 2;\"></span>\n    </div>\n  </div>",
+    "trimStrings": [],
+    "placement": [
+      1
+    ],
+    "substituteRegex": 0,
+    "minDepth": null,
+    "maxDepth": 2,
+    "markdownOnly": true,
+    "promptOnly": false
+  }
+]


### PR DESCRIPTION
## Summary
- add a `regex-rules.json` bundle so the extension ships the thinking-removal and user bubble replacements
- load the JSON at runtime and apply the configured regex rules to prompts and rendered messages
- document how to extend the built-in rules in `regex-rules.json`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da56d76e2c8322acac5353e96cb760