### PR TITLE
Organize navigation and adjust text spacing

### DIFF
--- a/script.js
+++ b/script.js
@@ -73,6 +73,7 @@
             </div>
             <div id="cip-panel-footer">
                 <div id="cip-footer-controls">
+                    <div id="cip-settings-button" title="设置">⚙️</div>
                     <div id="cip-sync-button" title="同步设置">☁️</div>
                     <div id="cip-theme-button" title="主题设置">👕</div>
                     <div id="cip-alarm-button" title="定时指令">⏰</div>
@@ -251,6 +252,29 @@
             `
         );
 
+        const settingsPanel = create(
+            'div',
+            'cip-settings-panel',
+            'cip-frosted-glass hidden',
+            `
+            <nav id="cip-settings-tabs">
+                <button class="cip-settings-tab-btn active" data-target="theme">主题设置</button>
+                <button class="cip-settings-tab-btn" data-target="avatar">头像配置</button>
+                <button class="cip-settings-tab-btn" data-target="alarm">定时指令</button>
+                <button class="cip-settings-tab-btn" data-target="sync">同步设置</button>
+            </nav>
+            <div id="cip-settings-content">
+                <div class="cip-settings-section active" data-section="theme"></div>
+                <div class="cip-settings-section" data-section="avatar"></div>
+                <div class="cip-settings-section" data-section="alarm"></div>
+                <div class="cip-settings-section" data-section="sync"></div>
+            </div>
+            <div class="cip-settings-footer">
+                <button id="cip-close-settings-panel-btn">完成</button>
+            </div>
+            `,
+        );
+
         return {
             carrotButton,
             inputPanel,
@@ -261,6 +285,7 @@
             alarmPanel,
             avatarPanel,
             syncPanel,
+            settingsPanel,
         };
     }
 // <BUNNY_CURSE>
@@ -291,6 +316,7 @@
         document.body.appendChild(alarmPanel);
         document.body.appendChild(avatarPanel);
         document.body.appendChild(syncPanel);
+        document.body.appendChild(settingsPanel);
     } else {
         console.error(
             '胡萝卜输入面板：未能找到SillyTavern的UI挂载点，插件无法加载。',
@@ -314,6 +340,7 @@
         addCategoryBtn = get('cip-add-category-btn'),
         stickerGrid = get('cip-sticker-grid');
     const emojiPickerBtn = get('cip-emoji-picker-btn');
+    const settingsButton = get('cip-settings-button');
     const saveCategoryBtn = get('cip-save-category-btn'),
         cancelCategoryBtn = get('cip-cancel-category-btn'),
         newCategoryNameInput = get('cip-new-category-name');
@@ -339,6 +366,8 @@
     const syncPathInput = get('cip-sync-path-input');
     const savePathBtn = get('cip-save-path-btn');
     const loadPathBtn = get('cip-load-path-btn');
+    const settingsPanelEl = get('cip-settings-panel');
+    const closeSettingsPanelBtn = get('cip-close-settings-panel-btn');
 
     // --- 新增: 定时指令元素引用 ---
     const alarmButton = get('cip-alarm-button');
@@ -1070,6 +1099,83 @@
             (selectedSticker = null),
             updateFormatDisplay());
     }
+
+    function switchSettingsTab(tab) {
+        queryAll('#cip-settings-panel .cip-settings-tab-btn').forEach((btn) => {
+            btn.classList.toggle('active', btn.dataset.target === tab);
+        });
+        queryAll('#cip-settings-panel .cip-settings-section').forEach((sec) => {
+            sec.classList.toggle('active', sec.dataset.section === tab);
+        });
+        // 确保嵌入的面板在设置面板内不受 .hidden 影响
+        if (themePanel) themePanel.classList.remove('hidden');
+        if (avatarPanel) avatarPanel.classList.remove('hidden');
+        if (alarmPanel) alarmPanel.classList.remove('hidden');
+        if (syncPanel) syncPanel.classList.remove('hidden');
+    }
+
+    function initSettingsPanelEmbed() {
+        if (!settingsPanelEl) return;
+        const themeSection = settingsPanelEl.querySelector(
+            '.cip-settings-section[data-section="theme"]',
+        );
+        const avatarSection = settingsPanelEl.querySelector(
+            '.cip-settings-section[data-section="avatar"]',
+        );
+        const alarmSection = settingsPanelEl.querySelector(
+            '.cip-settings-section[data-section="alarm"]',
+        );
+        const syncSection = settingsPanelEl.querySelector(
+            '.cip-settings-section[data-section="sync"]',
+        );
+
+        if (themePanel && themeSection && themePanel.parentElement !== themeSection) {
+            themeSection.appendChild(themePanel);
+        }
+        if (avatarPanel && avatarSection && avatarPanel.parentElement !== avatarSection) {
+            avatarSection.appendChild(avatarPanel);
+        }
+        if (alarmPanel && alarmSection && alarmPanel.parentElement !== alarmSection) {
+            alarmSection.appendChild(alarmPanel);
+        }
+        if (syncPanel && syncSection && syncPanel.parentElement !== syncSection) {
+            syncSection.appendChild(syncPanel);
+        }
+
+        // 移除 hidden 以便在设置面板中展示
+        if (themePanel) themePanel.classList.remove('hidden');
+        if (avatarPanel) avatarPanel.classList.remove('hidden');
+        if (alarmPanel) alarmPanel.classList.remove('hidden');
+        if (syncPanel) syncPanel.classList.remove('hidden');
+
+        // 绑定设置面板的Tab事件
+        queryAll('#cip-settings-panel .cip-settings-tab-btn').forEach((btn) => {
+            btn.addEventListener('click', (e) => {
+                const target = e.currentTarget.dataset.target;
+                switchSettingsTab(target);
+            });
+        });
+
+        if (closeSettingsPanelBtn) {
+            closeSettingsPanelBtn.addEventListener('click', () => {
+                settingsPanelEl.classList.add('hidden');
+            });
+        }
+
+        // 内部各面板原有“完成/关闭”按钮同时关闭设置面板
+        ;[
+            closeThemePanelBtn,
+            closeAlarmPanelBtn,
+            closeSyncPanelBtn,
+            closeAvatarPanelBtn,
+        ].forEach((btn) => {
+            if (btn) {
+                btn.addEventListener('click', () => {
+                    settingsPanelEl.classList.add('hidden');
+                });
+            }
+        });
+    }
     function renderStickers(t) {
         if (((stickerGrid.innerHTML = ''), !t || !stickerData[t]))
             return void (stickerGrid.innerHTML =
@@ -1730,6 +1836,15 @@
     });
 
     // --- 5. 交互处理逻辑 (无变化) ---
+    // 设置齿轮按钮事件
+    if (settingsButton) {
+        settingsButton.addEventListener('click', () => {
+            if (settingsPanelEl) {
+                settingsPanelEl.classList.remove('hidden');
+                switchSettingsTab('theme');
+            }
+        });
+    }
     function showPanel() {
         if (inputPanel.classList.contains('active')) return;
         const btnRect = carrotButton.getBoundingClientRect();
@@ -1966,6 +2081,7 @@
         if (savedFilename) {
             syncPathInput.value = savedFilename;
         }
+        initSettingsPanelEmbed();
         switchStickerCategory(Object.keys(stickerData)[0] || '');
         switchTab('text');
         setTimeout(checkAlarmOnLoad, 500);

--- a/style.css
+++ b/style.css
@@ -132,13 +132,13 @@
 .cip-sub-options-container {
     display: flex;
     flex-wrap: wrap;
-    gap: 8px;
+    gap: 6px;
     padding-bottom: 8px;
     border-bottom: 1px solid var(--cip-border-color);
     margin-bottom: 8px;
 }
 .cip-sub-option-btn {
-    padding: 4px 10px;
+    padding: 3px 8px;
     font-size: 12px;
     border: 1px solid var(--cip-border-color);
     border-radius: 16px;
@@ -251,6 +251,7 @@
     align-items: center;
     gap: 8px;
 }
+#cip-settings-button,
 #cip-sync-button,
 #cip-theme-button,
 #cip-alarm-button,
@@ -296,6 +297,13 @@
 }
 #cip-insert-button:hover {
     background-color: var(--cip-accent-hover-color); /* 应用变量 */
+}
+/* 将底部四个独立按钮隐藏，仅保留齿轮按钮入口 */
+#cip-footer-controls #cip-sync-button,
+#cip-footer-controls #cip-theme-button,
+#cip-footer-controls #cip-alarm-button,
+#cip-footer-controls #cip-avatar-button {
+    display: none;
 }
 emoji-picker {
     position: fixed;
@@ -992,4 +1000,95 @@ emoji-picker {
 }
 #cip-close-sync-panel-btn:hover {
     background-color: var(--cip-accent-hover-color);
+}
+/* --- 新增: 统一设置（齿轮）面板样式 --- */
+#cip-settings-panel {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 420px;
+    max-width: 92vw;
+    max-height: 82vh;
+    z-index: 1010;
+    display: flex;
+    flex-direction: column;
+    padding: 16px;
+    gap: 12px;
+    overflow: hidden;
+}
+#cip-settings-panel.hidden {
+    opacity: 0;
+    pointer-events: none;
+    transform: translate(-50%, -50%) scale(0.96);
+}
+#cip-settings-tabs {
+    display: flex;
+    gap: 8px;
+    background: var(--cip-tabs-bg-color);
+    border-bottom: 1px solid var(--cip-border-color);
+    padding: 8px;
+}
+.cip-settings-tab-btn {
+    flex: 1;
+    padding: 8px 10px;
+    border: none;
+    border-radius: 8px;
+    background: transparent;
+    color: var(--cip-text-color);
+    cursor: pointer;
+    transition: background-color var(--cip-transition-speed), color var(--cip-transition-speed);
+}
+.cip-settings-tab-btn.active {
+    background: var(--cip-active-bg-color);
+    font-weight: bold;
+}
+#cip-settings-content {
+    flex: 1;
+    overflow: auto;
+    padding: 8px;
+}
+.cip-settings-section { display: none; }
+.cip-settings-section.active { display: block; }
+.cip-settings-footer {
+    display: flex;
+    justify-content: center;
+    padding-top: 8px;
+}
+#cip-close-settings-panel-btn {
+    padding: 8px 16px;
+    border-radius: 8px;
+    border: none;
+    cursor: pointer;
+    background-color: #ddd;
+    color: #333;
+    font-size: 16px;
+    transition: background-color var(--cip-transition-speed);
+}
+#cip-close-settings-panel-btn:hover { background-color: #ccc; }
+
+/* 嵌入时重置子面板定位与尺寸 */
+#cip-settings-panel #cip-theme-settings-panel,
+#cip-settings-panel #cip-avatar-panel,
+#cip-settings-panel #cip-alarm-panel,
+#cip-settings-panel #cip-sync-panel {
+    position: static;
+    top: auto;
+    left: auto;
+    transform: none;
+    width: auto;
+    max-width: none;
+    max-height: none;
+    padding: 0;
+    box-shadow: none;
+    border: none;
+}
+
+@media (max-width: 480px) {
+    #cip-settings-panel {
+        width: calc(100vw - 20px);
+        padding: 12px;
+        gap: 10px;
+        max-height: calc(100vh - 40px);
+    }
 }


### PR DESCRIPTION
Consolidate four footer emoji buttons into a single gear icon with a tabbed settings panel, and adjust sub-option spacing to prevent text wrapping.

The previous four emoji buttons (👕, 🐇, ⏰, ☁) were replaced by a single gear icon. Clicking the gear opens a unified settings panel with tabs for "主题设置", "头像配置", "定时指令", and "同步设置", embedding the original panels within. Additionally, the spacing for the six text sub-options was reduced to prevent the "BUNNY" text from wrapping.

---
<a href="https://cursor.com/background-agent?bcId=bc-ff19bb8f-a490-4772-b454-041ae943c5ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ff19bb8f-a490-4772-b454-041ae943c5ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

