### PR TITLE
Consolidate settings controls into a tabbed gear menu

### DIFF
--- a/script.js
+++ b/script.js
@@ -73,10 +73,7 @@
             </div>
             <div id="cip-panel-footer">
                 <div id="cip-footer-controls">
-                    <div id="cip-sync-button" title="同步设置">☁️</div>
-                    <div id="cip-theme-button" title="主题设置">👕</div>
-                    <div id="cip-alarm-button" title="定时指令">⏰</div>
-                    <div id="cip-avatar-button" title="头像配置">🐰</div>
+                    <div id="cip-settings-button" title="功能设置">⚙️</div>
                     <input type="file" id="cip-import-settings-input" accept=".json" style="display: none;">
                 </div>
                 <div class="cip-footer-actions">
@@ -104,151 +101,144 @@
             'cip-modal-backdrop hidden',
             `<div class="cip-modal-content cip-frosted-glass"><h3 id="cip-add-sticker-title"></h3><p>每行一个，格式为：<br><code>表情包描述:图片链接</code></p><textarea id="cip-new-stickers-input" placeholder="可爱猫猫:https://example.com/cat.png\n狗狗点头:https://example.com/dog.gif"></textarea><div class="cip-modal-actions"><button id="cip-cancel-stickers-btn">取消</button><button id="cip-save-stickers-btn">保存</button></div></div>`,
         );
-        const alarmPanel = create(
+        const settingsPanel = create(
             'div',
-            'cip-alarm-panel',
+            'cip-settings-panel',
             'cip-frosted-glass hidden',
             `
-            <h3>定时指令设置</h3>
-            <div class="cip-alarm-grid">
-                <label for="cip-alarm-hours">时:</label>
-                <input type="number" id="cip-alarm-hours" min="0" placeholder="h">
-                <label for="cip-alarm-minutes">分:</label>
-                <input type="number" id="cip-alarm-minutes" min="0" max="59" placeholder="m">
-                <label for="cip-alarm-seconds">秒:</label>
-                <input type="number" id="cip-alarm-seconds" min="0" max="59" placeholder="s">
+            <div class="cip-settings-header">
+                <nav id="cip-settings-tabs">
+                    <button class="cip-settings-tab active" data-target="theme">主题设置</button>
+                    <button class="cip-settings-tab" data-target="avatar">头像配置</button>
+                    <button class="cip-settings-tab" data-target="alarm">定时指令</button>
+                    <button class="cip-settings-tab" data-target="sync">同步设置</button>
+                </nav>
             </div>
-            <div class="cip-alarm-grid" style="margin-top: 10px;">
-                <label for="cip-alarm-repeat">次数:</label>
-                <input type="number" id="cip-alarm-repeat" min="1" placeholder="默认1次">
-                <span class="cip-alarm-note" colspan="2">(留空或1为单次)</span>
+            <div id="cip-settings-sections">
+                <section id="cip-settings-theme" class="cip-settings-section active">
+                    <h3>主题与颜色设置</h3>
+                    <div class="cip-theme-options-grid">
+                        <label for="cip-color-accent">主要/高亮颜色:</label>
+                        <div class="cip-color-input-wrapper">
+                            <input type="text" id="cip-color-accent" data-var="--cip-accent-color">
+                            <input type="color" class="cip-color-picker" data-target="cip-color-accent">
+                        </div>
+
+                        <label for="cip-color-accent-hover">高亮悬浮颜色:</label>
+                        <div class="cip-color-input-wrapper">
+                            <input type="text" id="cip-color-accent-hover" data-var="--cip-accent-hover-color">
+                            <input type="color" class="cip-color-picker" data-target="cip-color-accent-hover">
+                        </div>
+
+                        <label for="cip-color-insert-text">插入按钮文字:</label>
+                        <div class="cip-color-input-wrapper">
+                            <input type="text" id="cip-color-insert-text" data-var="--cip-insert-text-color">
+                            <input type="color" class="cip-color-picker" data-target="cip-color-insert-text">
+                        </div>
+
+                        <label for="cip-color-panel-bg">面板背景:</label>
+                        <div class="cip-color-input-wrapper">
+                            <input type="text" id="cip-color-panel-bg" data-var="--cip-panel-bg-color">
+                            <input type="color" class="cip-color-picker" data-target="cip-color-panel-bg">
+                        </div>
+
+                        <label for="cip-color-tabs-bg">功能栏背景:</label>
+                        <div class="cip-color-input-wrapper">
+                            <input type="text" id="cip-color-tabs-bg" data-var="--cip-tabs-bg-color">
+                            <input type="color" class="cip-color-picker" data-target="cip-color-tabs-bg">
+                        </div>
+
+                        <label for="cip-color-text">功能栏字体:</label>
+                        <div class="cip-color-input-wrapper">
+                            <input type="text" id="cip-color-text" data-var="--cip-text-color">
+                            <input type="color" class="cip-color-picker" data-target="cip-color-text">
+                        </div>
+
+                        <label for="cip-color-input-bg">输入框背景:</label>
+                        <div class="cip-color-input-wrapper">
+                            <input type="text" id="cip-color-input-bg" data-var="--cip-input-bg-color">
+                            <input type="color" class="cip-color-picker" data-target="cip-color-input-bg">
+                        </div>
+                    </div>
+                    <div class="cip-theme-manager">
+                        <div class="cip-theme-actions">
+                            <select id="cip-theme-select"></select>
+                            <button id="cip-delete-theme-btn" class="cip-delete-btn">删除</button>
+                        </div>
+                        <div class="cip-theme-save-new">
+                            <input type="text" id="cip-new-theme-name" placeholder="输入新配色方案名称...">
+                            <button id="cip-save-theme-btn" class="cip-save-btn">保存</button>
+                        </div>
+                    </div>
+                </section>
+                <section id="cip-settings-avatar" class="cip-settings-section">
+                    <h3>头像配置</h3>
+                    <div class="cip-avatar-grid">
+                        <label for="cip-char-avatar-url">角色 (Char):</label>
+                        <input type="text" id="cip-char-avatar-url" placeholder="粘贴角色头像链接...">
+
+                        <label for="cip-user-avatar-url">你 (User):</label>
+                        <input type="text" id="cip-user-avatar-url" placeholder="粘贴你的头像链接...">
+                        <label for="cip-unsplash-access-key">Unsplash Access Key:</label>
+                        <input type="text" id="cip-unsplash-access-key" placeholder="输入你的 Unsplash Access Key...">
+                    </div>
+
+                    <div class="cip-avatar-manager">
+                        <div class="cip-avatar-actions">
+                            <select id="cip-avatar-profile-select"></select>
+                            <button id="cip-apply-avatar-btn" class="cip-apply-btn">应用</button>
+                            <button id="cip-delete-avatar-btn" class="cip-delete-btn">删除</button>
+                        </div>
+                        <div class="cip-avatar-save-new">
+                            <input type="text" id="cip-new-avatar-profile-name" placeholder="输入新配置名称...">
+                            <button id="cip-save-avatar-btn" class="cip-apply-btn">保存</button>
+                        </div>
+                    </div>
+                </section>
+                <section id="cip-settings-alarm" class="cip-settings-section">
+                    <h3>定时指令设置</h3>
+                    <div class="cip-alarm-grid">
+                        <label for="cip-alarm-hours">时:</label>
+                        <input type="number" id="cip-alarm-hours" min="0" placeholder="h">
+                        <label for="cip-alarm-minutes">分:</label>
+                        <input type="number" id="cip-alarm-minutes" min="0" max="59" placeholder="m">
+                        <label for="cip-alarm-seconds">秒:</label>
+                        <input type="number" id="cip-alarm-seconds" min="0" max="59" placeholder="s">
+                    </div>
+                    <div class="cip-alarm-grid" style="margin-top: 10px;">
+                        <label for="cip-alarm-repeat">次数:</label>
+                        <input type="number" id="cip-alarm-repeat" min="1" placeholder="默认1次">
+                        <span class="cip-alarm-note" colspan="2">(留空或1为单次)</span>
+                    </div>
+                    <textarea id="cip-alarm-command" placeholder="在此输入定时执行的指令..."></textarea>
+                    <div id="cip-alarm-status">状态: 未设置</div>
+                    <div class="cip-alarm-actions">
+                        <button id="cip-restore-defaults-btn">恢复默认</button>
+                        <button id="cip-stop-alarm-btn">停止</button>
+                        <button id="cip-start-alarm-btn">启动</button>
+                    </div>
+                </section>
+                <section id="cip-settings-sync" class="cip-settings-section">
+                    <h3>同步设置</h3>
+                    <div class="cip-sync-actions">
+                        <button id="cip-export-btn-panel">导出设置</button>
+                        <label for="cip-import-settings-input" id="cip-import-label-panel" class="cip-button-label">导入设置</label>
+                    </div>
+                    <div class="cip-sync-path-container">
+                        <label for="cip-sync-path-input">保存到:</label>
+                        <input type="text" id="cip-sync-path-input" placeholder="输入默认文件名 (例如: settings.json)">
+                    </div>
+                    <div class="cip-sync-path-actions">
+                         <button id="cip-save-path-btn">保存</button>
+                         <button id="cip-load-path-btn">加载</button>
+                    </div>
+                    <p class="cip-sync-note">提示：由于浏览器安全限制，"保存"将使用上方文件名弹出另存为对话框，"加载"会打开文件选择框。</p>
+                </section>
             </div>
-            <textarea id="cip-alarm-command" placeholder="在此输入定时执行的指令..."></textarea>
-            <div id="cip-alarm-status">状态: 未设置</div>
-            <div class="cip-alarm-actions">
-                <button id="cip-restore-defaults-btn">恢复默认</button>
-                <button id="cip-stop-alarm-btn">停止</button>
-                <button id="cip-start-alarm-btn">启动</button>
+            <div class="cip-settings-footer">
+                <button id="cip-close-settings-panel-btn">完成</button>
             </div>
-            <button id="cip-close-alarm-panel-btn">完成</button>
-        `,
-        );
-
-        const themePanel = create(
-            'div',
-            'cip-theme-settings-panel',
-            'cip-frosted-glass hidden',
-            `
-            <h3>主题与颜色设置</h3>
-            <div class="cip-theme-options-grid">
-                <label for="cip-color-accent">主要/高亮颜色:</label>
-                <div class="cip-color-input-wrapper">
-                    <input type="text" id="cip-color-accent" data-var="--cip-accent-color">
-                    <input type="color" class="cip-color-picker" data-target="cip-color-accent">
-                </div>
-
-                <label for="cip-color-accent-hover">高亮悬浮颜色:</label>
-                <div class="cip-color-input-wrapper">
-                    <input type="text" id="cip-color-accent-hover" data-var="--cip-accent-hover-color">
-                    <input type="color" class="cip-color-picker" data-target="cip-color-accent-hover">
-                </div>
-
-                <label for="cip-color-insert-text">插入按钮文字:</label>
-                <div class="cip-color-input-wrapper">
-                    <input type="text" id="cip-color-insert-text" data-var="--cip-insert-text-color">
-                    <input type="color" class="cip-color-picker" data-target="cip-color-insert-text">
-                </div>
-
-                <label for="cip-color-panel-bg">面板背景:</label>
-                <div class="cip-color-input-wrapper">
-                    <input type="text" id="cip-color-panel-bg" data-var="--cip-panel-bg-color">
-                    <input type="color" class="cip-color-picker" data-target="cip-color-panel-bg">
-                </div>
-
-                <label for="cip-color-tabs-bg">功能栏背景:</label>
-                <div class="cip-color-input-wrapper">
-                    <input type="text" id="cip-color-tabs-bg" data-var="--cip-tabs-bg-color">
-                    <input type="color" class="cip-color-picker" data-target="cip-color-tabs-bg">
-                </div>
-
-                <label for="cip-color-text">功能栏字体:</label>
-                <div class="cip-color-input-wrapper">
-                    <input type="text" id="cip-color-text" data-var="--cip-text-color">
-                    <input type="color" class="cip-color-picker" data-target="cip-color-text">
-                </div>
-
-                <label for="cip-color-input-bg">输入框背景:</label>
-                <div class="cip-color-input-wrapper">
-                    <input type="text" id="cip-color-input-bg" data-var="--cip-input-bg-color">
-                    <input type="color" class="cip-color-picker" data-target="cip-color-input-bg">
-                </div>
-            </div>
-            <div class="cip-theme-manager">
-                <div class="cip-theme-actions">
-                    <select id="cip-theme-select"></select>
-                    <button id="cip-delete-theme-btn" class="cip-delete-btn">删除</button>
-                </div>
-                <div class="cip-theme-save-new">
-                    <input type="text" id="cip-new-theme-name" placeholder="输入新配色方案名称...">
-                    <button id="cip-save-theme-btn" class="cip-save-btn">保存</button>
-                </div>
-            </div>
-            <button id="cip-close-theme-panel-btn">完成</button>
-        `,
-        );
-        const avatarPanel = create(
-           'div',
-            'cip-avatar-panel',
-           'cip-frosted-glass hidden',
-           `
-            <h3>头像配置</h3>
-            <div class="cip-avatar-grid">
-              <label for="cip-char-avatar-url">角色 (Char):</label>
-              <input type="text" id="cip-char-avatar-url" placeholder="粘贴角色头像链接...">
-
-              <label for="cip-user-avatar-url">你 (User):</label>
-               <input type="text" id="cip-user-avatar-url" placeholder="粘贴你的头像链接...">
-               <label for="cip-unsplash-access-key">Unsplash Access Key:</label>
-               <input type="text" id="cip-unsplash-access-key" placeholder="输入你的 Unsplash Access Key...">
-            </div>
-
-            <div class="cip-avatar-manager">
-             <div class="cip-avatar-actions">
-                   <select id="cip-avatar-profile-select"></select>
-                  <button id="cip-apply-avatar-btn" class="cip-apply-btn">应用</button>
-                 <button id="cip-delete-avatar-btn" class="cip-delete-btn">删除</button>
-             </div>
-                <div class="cip-avatar-save-new">
-                    <input type="text" id="cip-new-avatar-profile-name" placeholder="输入新配置名称...">
-                   <button id="cip-save-avatar-btn" class="cip-apply-btn">保存</button>
-             </div>
-            </div>
-
-            <button id="cip-close-avatar-panel-btn">关闭</button>
-            `
-        );
-        
-        const syncPanel = create(
-            'div',
-            'cip-sync-panel',
-            'cip-frosted-glass hidden',
-            `
-            <h3>同步设置</h3>
-            <div class="cip-sync-actions">
-                <button id="cip-export-btn-panel">导出设置</button>
-                <label for="cip-import-settings-input" id="cip-import-label-panel" class="cip-button-label">导入设置</label>
-            </div>
-            <div class="cip-sync-path-container">
-                <label for="cip-sync-path-input">保存到:</label>
-                <input type="text" id="cip-sync-path-input" placeholder="输入默认文件名 (例如: settings.json)">
-            </div>
-            <div class="cip-sync-path-actions">
-                 <button id="cip-save-path-btn">保存</button>
-                 <button id="cip-load-path-btn">加载</button>
-            </div>
-            <p class="cip-sync-note">提示：由于浏览器安全限制，"保存"将使用上方文件名弹出另存为对话框，"加载"会打开文件选择框。</p>
-            <button id="cip-close-sync-panel-btn">关闭</button>
-            `
+            `,
         );
 
         return {
@@ -257,10 +247,7 @@
             emojiPicker,
             addCategoryModal,
             addStickersModal,
-            themePanel,
-            alarmPanel,
-            avatarPanel,
-            syncPanel,
+            settingsPanel,
         };
     }
 // <BUNNY_CURSE>
@@ -273,10 +260,7 @@
         emojiPicker,
         addCategoryModal,
         addStickersModal,
-        themePanel,
-        alarmPanel,
-        avatarPanel,
-        syncPanel,
+        settingsPanel,
     } = createUI();
     const anchor = document.querySelector(
         '#chat-buttons-container, #send_form',
@@ -287,10 +271,7 @@
         document.body.appendChild(emojiPicker);
         document.body.appendChild(addCategoryModal);
         document.body.appendChild(addStickersModal);
-        document.body.appendChild(themePanel);
-        document.body.appendChild(alarmPanel);
-        document.body.appendChild(avatarPanel);
-        document.body.appendChild(syncPanel);
+        document.body.appendChild(settingsPanel);
     } else {
         console.error(
             '胡萝卜输入面板：未能找到SillyTavern的UI挂载点，插件无法加载。',
@@ -321,8 +302,11 @@
         saveStickersBtn = get('cip-save-stickers-btn'),
         cancelStickersBtn = get('cip-cancel-stickers-btn'),
         newStickersInput = get('cip-new-stickers-input');
-    const themeButton = get('cip-theme-button');
-    const closeThemePanelBtn = get('cip-close-theme-panel-btn');
+    const settingsButton = get('cip-settings-button');
+    const settingsPanelEl = get('cip-settings-panel');
+    const closeSettingsPanelBtn = get('cip-close-settings-panel-btn');
+    const settingsTabs = Array.from(queryAll('.cip-settings-tab'));
+    const settingsSections = Array.from(queryAll('.cip-settings-section'));
     const colorInputs = queryAll('.cip-theme-options-grid input[type="text"]');
     const colorPickers = queryAll('.cip-color-picker');
     const themeSelect = get('cip-theme-select');
@@ -332,8 +316,6 @@
     
     // --- 新增: 导入/同步元素引用 ---
     const importSettingsInput = get('cip-import-settings-input');
-    const syncButton = get('cip-sync-button');
-    const closeSyncPanelBtn = get('cip-close-sync-panel-btn');
     const exportBtnPanel = get('cip-export-btn-panel');
     const importLabelPanel = get('cip-import-label-panel');
     const syncPathInput = get('cip-sync-path-input');
@@ -341,8 +323,6 @@
     const loadPathBtn = get('cip-load-path-btn');
 
     // --- 新增: 定时指令元素引用 ---
-    const alarmButton = get('cip-alarm-button');
-    const closeAlarmPanelBtn = get('cip-close-alarm-panel-btn');
     const startAlarmBtn = get('cip-start-alarm-btn');
     const stopAlarmBtn = get('cip-stop-alarm-btn');
     const alarmHoursInput = get('cip-alarm-hours');
@@ -353,8 +333,6 @@
     const alarmRepeatInput = get('cip-alarm-repeat');
     const restoreDefaultsBtn = get('cip-restore-defaults-btn');
     // --- 新增: 头像配置元素引用 ---
-    const avatarButton = get('cip-avatar-button');
-    const closeAvatarPanelBtn = get('cip-close-avatar-panel-btn');
     const charAvatarUrlInput = get('cip-char-avatar-url');
     const userAvatarUrlInput = get('cip-user-avatar-url');
     const unsplashAccessKeyInput = get('cip-unsplash-access-key');
@@ -951,10 +929,6 @@
         alarmRepeatInput.value = alarmData ? alarmData.repeat || 1 : 1;
         updateAlarmStatus(null);
     }
-    // --- 新增: 头像配置事件监听 ---
-    avatarButton.addEventListener('click', () => get('cip-avatar-panel').classList.remove('hidden'));
-    closeAvatarPanelBtn.addEventListener('click', () => get('cip-avatar-panel').classList.add('hidden'));
-
     applyAvatarBtn.addEventListener('click', () => {
         const charUrl = charAvatarUrlInput.value.trim();
         const userUrl = userAvatarUrlInput.value.trim();
@@ -982,8 +956,6 @@
 
     // --- 新增: 导入/同步事件监听 ---
     importSettingsInput.addEventListener('change', importSettings);
-    syncButton.addEventListener('click', () => syncPanel.classList.remove('hidden'));
-    closeSyncPanelBtn.addEventListener('click', () => syncPanel.classList.add('hidden'));
     exportBtnPanel.addEventListener('click', () => exportSettings());
     savePathBtn.addEventListener('click', saveToPath);
     loadPathBtn.addEventListener('click', () => {
@@ -1656,13 +1628,40 @@
         } else alert('未能解析任何有效的表情包信息。');
     });
 
-    // --- 主题设置事件监听 ---
-    themeButton.addEventListener('click', () =>
-        themePanel.classList.remove('hidden'),
-    );
-    closeThemePanelBtn.addEventListener('click', () =>
-        themePanel.classList.add('hidden'),
-    );
+    // --- 设置面板事件监听 ---
+    function activateSettingsTab(target) {
+        if (!target) return;
+        settingsTabs.forEach((tab) => {
+            tab.classList.toggle('active', tab.dataset.target === target);
+        });
+        settingsSections.forEach((section) => {
+            section.classList.toggle(
+                'active',
+                section.id === `cip-settings-${target}`,
+            );
+        });
+    }
+
+    settingsTabs.forEach((tab) => {
+        tab.addEventListener('click', () => {
+            activateSettingsTab(tab.dataset.target);
+        });
+    });
+
+    settingsButton?.addEventListener('click', () => {
+        if (!settingsPanelEl) return;
+        settingsPanelEl.classList.remove('hidden');
+        const activeTab = settingsTabs.find((tab) =>
+            tab.classList.contains('active'),
+        );
+        if (!activeTab && settingsTabs.length > 0) {
+            activateSettingsTab(settingsTabs[0].dataset.target);
+        }
+    });
+
+    closeSettingsPanelBtn?.addEventListener('click', () => {
+        settingsPanelEl?.classList.add('hidden');
+    });
 
     colorInputs.forEach((input) => {
         input.addEventListener('input', (e) => {
@@ -1714,12 +1713,6 @@
     deleteThemeBtn.addEventListener('click', deleteSelectedTheme);
 
     // --- 定时指令事件监听 ---
-    alarmButton.addEventListener('click', () =>
-        get('cip-alarm-panel').classList.remove('hidden'),
-    );
-    closeAlarmPanelBtn.addEventListener('click', () =>
-        get('cip-alarm-panel').classList.add('hidden'),
-    );
     startAlarmBtn.addEventListener('click', () => startAlarm(false));
     stopAlarmBtn.addEventListener('click', () => stopAlarm());
     restoreDefaultsBtn.addEventListener('click', () => {

--- a/style.css
+++ b/style.css
@@ -132,7 +132,7 @@
 .cip-sub-options-container {
     display: flex;
     flex-wrap: wrap;
-    gap: 8px;
+    gap: 4px;
     padding-bottom: 8px;
     border-bottom: 1px solid var(--cip-border-color);
     margin-bottom: 8px;
@@ -251,11 +251,7 @@
     align-items: center;
     gap: 8px;
 }
-#cip-sync-button,
-#cip-theme-button,
-#cip-alarm-button,
-#cip-export-settings-btn,
-#cip-import-settings-btn {
+#cip-settings-button {
     font-size: 24px;
     cursor: pointer;
     opacity: 0.7;
@@ -263,10 +259,7 @@
     position: relative;
     user-select: none;
 }
-#cip-export-settings-btn:hover,
-#cip-import-settings-btn:hover,
-#cip-theme-button:hover,
-#cip-alarm-button:hover {
+#cip-settings-button:hover {
     opacity: 1;
 }
 .cip-footer-actions {
@@ -399,34 +392,89 @@ emoji-picker {
     box-sizing: border-box;
 }
 
-/* --- 新增: 主题设置面板样式 --- */
-#cip-theme-settings-panel {
-    position: absolute;
+/* --- 设置面板样式 --- */
+#cip-settings-panel {
+    position: fixed;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    width: 380px;
+    width: 400px;
     max-width: 90vw;
     max-height: 80vh;
-    z-index: 1004;
+    z-index: 1005;
     display: flex;
     flex-direction: column;
     padding: 20px;
     gap: 16px;
-    overflow-y: auto;
+    overflow: hidden;
+}
+#cip-settings-panel.hidden {
+    display: none;
+}
+.cip-settings-header {
+    border-bottom: 1px solid var(--cip-border-color);
+    padding-bottom: 8px;
+}
+#cip-settings-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+.cip-settings-tab {
+    flex: 1;
+    min-width: 120px;
+    padding: 8px 12px;
+    border: 1px solid var(--cip-border-color);
+    border-radius: 999px;
+    background: transparent;
+    color: var(--cip-text-color);
+    cursor: pointer;
     transition:
-        opacity var(--cip-transition-speed),
-        transform var(--cip-transition-speed);
+        background-color var(--cip-transition-speed),
+        color var(--cip-transition-speed);
 }
-#cip-theme-settings-panel.hidden {
-    opacity: 0;
-    pointer-events: none;
-    transform: translate(-50%, -50%) scale(0.95);
+.cip-settings-tab.active {
+    background-color: var(--cip-accent-color);
+    color: #fff;
+    border-color: var(--cip-accent-color);
 }
-#cip-theme-settings-panel h3 {
-    margin: 0 0 10px 0;
+#cip-settings-sections {
+    flex: 1;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    padding-right: 4px;
+}
+.cip-settings-section {
+    display: none;
+    flex-direction: column;
+    gap: 16px;
+}
+.cip-settings-section.active {
+    display: flex;
+}
+.cip-settings-section h3 {
+    margin: 0;
     text-align: center;
     color: var(--cip-text-color);
+}
+.cip-settings-footer {
+    display: flex;
+    justify-content: center;
+}
+.cip-settings-footer button {
+    padding: 10px 24px;
+    border-radius: 999px;
+    border: none;
+    cursor: pointer;
+    font-size: 16px;
+    font-weight: bold;
+    background-color: var(--cip-accent-color);
+    color: var(--cip-insert-text-color);
+    transition: background-color var(--cip-transition-speed);
+}
+.cip-settings-footer button:hover {
+    background-color: var(--cip-accent-hover-color);
 }
 .cip-theme-options-grid {
     display: grid;
@@ -533,49 +581,7 @@ emoji-picker {
     background-color: var(--cip-delete-color);
     color: white;
 }
-#cip-close-theme-panel-btn {
-    margin: 10px auto 0;
-    width: 50%;
-    padding: 10px;
-    border-radius: 8px;
-    border: none;
-    cursor: pointer;
-    background-color: #ddd;
-    color: #333;
-    font-size: 16px;
-    transition: background-color var(--cip-transition-speed);
-}
-#cip-close-theme-panel-btn:hover {
-    background-color: #ccc;
-}
-
 /* --- 新增: 定时指令面板样式 --- */
-#cip-alarm-panel {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    width: 350px;
-    max-width: 90vw;
-    z-index: 1005; /* 比主题面板高一级 */
-    display: flex;
-    flex-direction: column;
-    padding: 20px;
-    gap: 15px;
-    transition:
-        opacity var(--cip-transition-speed),
-        transform var(--cip-transition-speed);
-}
-#cip-alarm-panel.hidden {
-    opacity: 0;
-    pointer-events: none;
-    transform: translate(-50%, -50%) scale(0.95);
-}
-#cip-alarm-panel h3 {
-    margin: 0 0 5px 0;
-    text-align: center;
-    color: var(--cip-text-color);
-}
 .cip-alarm-grid {
     display: grid;
     grid-template-columns: 1fr 1fr 1fr 1fr;
@@ -665,21 +671,6 @@ emoji-picker {
     flex-grow: 0;
     padding: 10px 15px;
 }
-#cip-close-alarm-panel-btn {
-    margin-top: 5px;
-    width: 100%;
-    padding: 10px;
-    border-radius: 8px;
-    border: none;
-    cursor: pointer;
-    background-color: var(--cip-accent-color);
-    color: #333;
-    font-size: 16px;
-    transition: background-color var(--cip-transition-speed);
-}
-#cip-close-alarm-panel-btn:hover {
-    background-color: var(--cip-accent-hover-color);
-}
 /* ---- */
 
 @media (max-width: 768px) {
@@ -695,7 +686,7 @@ emoji-picker {
 }
 @media (max-width: 480px) {
     .cip-modal-content,
-    #cip-theme-settings-panel {
+    #cip-settings-panel {
         width: calc(100vw - 20px);
         padding: 12px;
         gap: 12px;
@@ -704,7 +695,7 @@ emoji-picker {
         padding: 10px;
     }
     .cip-modal-content h3,
-    #cip-theme-settings-panel h3 {
+    .cip-settings-section h3 {
         font-size: 16px;
         margin: 0;
     }
@@ -773,50 +764,6 @@ emoji-picker {
     color: white;
 }
 /* --- 新增: 头像配置面板样式 --- */
-#cip-avatar-button {
-    font-size: 24px;
-    cursor: pointer;
-    opacity: 0.7;
-    transition: opacity var(--cip-transition-speed);
-    position: relative;
-    user-select: none;
-}
-
-#cip-avatar-button:hover {
-    opacity: 1;
-}
-
-#cip-avatar-panel {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    width: 380px;
-    max-width: 90vw;
-    max-height: 80vh;
-    z-index: 1006; /* 比定时面板层级更高 */
-    display: flex;
-    flex-direction: column;
-    padding: 20px;
-    gap: 16px;
-    overflow-y: auto;
-    transition:
-        opacity var(--cip-transition-speed),
-        transform var(--cip-transition-speed);
-}
-
-#cip-avatar-panel.hidden {
-    opacity: 0;
-    pointer-events: none;
-    transform: translate(-50%, -50%) scale(0.95);
-}
-
-#cip-avatar-panel h3 {
-    margin: 0 0 10px 0;
-    text-align: center;
-    color: var(--cip-text-color);
-}
-
 .cip-avatar-grid {
     display: grid;
     grid-template-columns: 100px 1fr;
@@ -887,47 +834,12 @@ emoji-picker {
     color: white;
 }
 
-#cip-close-avatar-panel-btn {
-    margin: 10px auto 0;
-    width: 50%;
-    padding: 10px;
-    border-radius: 8px;
-    border: none;
-    cursor: pointer;
-    background-color: #ddd;
-    color: #333;
-    font-size: 16px;
-    transition: background-color var(--cip-transition-speed);
+.cip-avatar-manager button.cip-delete-btn {
+    background-color: var(--cip-delete-color);
+    color: white;
 }
 
-#cip-close-avatar-panel-btn:hover {
-    background-color: #ccc;
-}
 /* --- 新增: 同步设置面板样式 --- */
-#cip-sync-panel {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    width: 380px;
-    max-width: 90vw;
-    z-index: 1007; /* 层级最高 */
-    display: flex;
-    flex-direction: column;
-    padding: 20px;
-    gap: 16px;
-    transition: opacity var(--cip-transition-speed), transform var(--cip-transition-speed);
-}
-#cip-sync-panel.hidden {
-    opacity: 0;
-    pointer-events: none;
-    transform: translate(-50%, -50%) scale(0.95);
-}
-#cip-sync-panel h3 {
-    margin: 0 0 10px 0;
-    text-align: center;
-    color: var(--cip-text-color);
-}
 .cip-sync-actions, .cip-sync-path-actions {
     display: flex;
     gap: 10px;
@@ -977,19 +889,4 @@ emoji-picker {
     padding: 8px;
     background: rgba(0,0,0,0.05);
     border-radius: 8px;
-}
-#cip-close-sync-panel-btn {
-    margin-top: 10px;
-    padding: 10px;
-    border-radius: 8px;
-    border: none;
-    cursor: pointer;
-    background-color: var(--cip-accent-color);
-    color: var(--cip-insert-text-color);
-    font-size: 16px;
-    font-weight: bold;
-    transition: background-color var(--cip-transition-speed);
-}
-#cip-close-sync-panel-btn:hover {
-    background-color: var(--cip-accent-hover-color);
 }


### PR DESCRIPTION
## Summary
- replace the four footer emoji shortcuts with a single gear button that opens a tabbed settings panel for theme, avatar, alarm, and sync configuration
- add tab activation logic and update event handlers to work with the consolidated settings panel
- tighten the sub-option button spacing so the BUNNY option no longer wraps

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dec8a71ba083228d9cf28248a1b703