### PR TITLE
Add ElevenLabs TTS vendor support and settings

### DIFF
--- a/script.js
+++ b/script.js
@@ -328,26 +328,63 @@
                 <section id="cip-settings-voice" class="cip-settings-section">
                     <div class="cip-tts-subtabs">
                         <button class="cip-tts-subtab active" data-subtab="settings">语音设置</button>
-                        <span class="cip-tts-divider">｜</span>
-                        <button class="cip-tts-subtab" data-subtab="upload">上传音色</button>
+                        <span class="cip-tts-divider" data-tts-vendor="silicon_flow">｜</span>
+                        <button class="cip-tts-subtab" data-subtab="upload" data-tts-vendor="silicon_flow">上传音色</button>
                     </div>
                     <hr class="cip-tts-separator">
 
                     <div id="cip-tts-pane-settings" class="cip-tts-pane active">
                         <div class="cip-tts-grid">
-                            <label for="cip-tts-key">API</label>
-                            <input type="password" id="cip-tts-key" placeholder="填写硅基流动 API Key">
+                            <label for="cip-tts-vendor">厂商</label>
+                            <select id="cip-tts-vendor">
+                                <option value="silicon_flow">硅基流动</option>
+                                <option value="elevenlabs">ElevenLabs</option>
+                            </select>
 
-                            <label for="cip-tts-endpoint">API端点</label>
-                            <input type="text" id="cip-tts-endpoint" placeholder="自动设置，无需填写">
+                            <div class="cip-tts-vendor-group" data-tts-vendor="silicon_flow">
+                                <label for="cip-tts-key">API</label>
+                                <input type="password" id="cip-tts-key" placeholder="填写硅基流动 API Key">
 
-                            <label for="cip-tts-model">模型</label>
-                            <select id="cip-tts-model"></select>
+                                <label for="cip-tts-endpoint">API端点</label>
+                                <input type="text" id="cip-tts-endpoint" placeholder="自动设置，无需填写">
 
-                            <label for="cip-tts-voice">音色</label>
-                            <div class="cip-tts-voice-row">
-                                <select id="cip-tts-voice"></select>
-                                <button id="cip-tts-voice-delete" title="删除音色">×</button>
+                                <label for="cip-tts-model">模型</label>
+                                <select id="cip-tts-model"></select>
+
+                                <label for="cip-tts-voice">音色</label>
+                                <div class="cip-tts-voice-row">
+                                    <select id="cip-tts-voice"></select>
+                                    <button id="cip-tts-voice-delete" title="删除音色">×</button>
+                                </div>
+                            </div>
+
+                            <div class="cip-tts-vendor-group" data-tts-vendor="elevenlabs" hidden>
+                                <label for="cip-tts-eleven-api-key">API Key</label>
+                                <input type="password" id="cip-tts-eleven-api-key" placeholder="填写 ElevenLabs API Key">
+
+                                <label for="cip-tts-eleven-voice-id">Voice ID</label>
+                                <input type="text" id="cip-tts-eleven-voice-id" placeholder="目标 Voice ID">
+
+                                <label for="cip-tts-eleven-model-id">Model ID</label>
+                                <input type="text" id="cip-tts-eleven-model-id" placeholder="默认 eleven_multilingual_v2">
+
+                                <label for="cip-tts-eleven-latency">流式延迟等级</label>
+                                <input type="number" id="cip-tts-eleven-latency" min="0" max="4" step="1" placeholder="0-4，可选">
+
+                                <label for="cip-tts-eleven-stability">Stability</label>
+                                <input type="number" id="cip-tts-eleven-stability" min="0" max="1" step="0.05" placeholder="0-1，可选">
+
+                                <label for="cip-tts-eleven-similarity">Similarity Boost</label>
+                                <input type="number" id="cip-tts-eleven-similarity" min="0" max="1" step="0.05" placeholder="0-1，可选">
+
+                                <label for="cip-tts-eleven-style">Style</label>
+                                <input type="number" id="cip-tts-eleven-style" min="0" max="100" step="1" placeholder="0-100，可选">
+
+                                <label for="cip-tts-eleven-speaker-boost">Speaker Boost</label>
+                                <div class="cip-tts-checkbox-row">
+                                    <input type="checkbox" id="cip-tts-eleven-speaker-boost">
+                                    <span>启用 Speaker Boost</span>
+                                </div>
                             </div>
                         </div>
                         <div class="cip-tts-test">
@@ -366,7 +403,7 @@
                         </div>
                     </div>
 
-                    <div id="cip-tts-pane-upload" class="cip-tts-pane">
+                    <div id="cip-tts-pane-upload" class="cip-tts-pane" data-tts-vendor="silicon_flow">
                         <div class="cip-tts-upload-grid">
                             <label for="cip-tts-upload-name">音色名称</label>
                             <input type="text" id="cip-tts-upload-name" placeholder="仅字母/数字">
@@ -503,11 +540,23 @@
     const restoreDefaultsBtn = get('cip-restore-defaults-btn');
     // --- 新增: 语音设置元素引用 ---
     // provider/MiniMax 已移除
+    const ttsVendorSelect = get('cip-tts-vendor');
+    const ttsVendorGroups = Array.from(
+        document.querySelectorAll('.cip-tts-vendor-group'),
+    );
     const ttsKeyInput = get('cip-tts-key');
     const ttsModelInput = get('cip-tts-model');
     const ttsVoiceInput = get('cip-tts-voice');
     const ttsEndpointInput = get('cip-tts-endpoint');
     const ttsEndpointLabel = document.querySelector('label[for="cip-tts-endpoint"]');
+    const ttsElevenApiKeyInput = get('cip-tts-eleven-api-key');
+    const ttsElevenVoiceIdInput = get('cip-tts-eleven-voice-id');
+    const ttsElevenModelIdInput = get('cip-tts-eleven-model-id');
+    const ttsElevenLatencyInput = get('cip-tts-eleven-latency');
+    const ttsElevenStabilityInput = get('cip-tts-eleven-stability');
+    const ttsElevenSimilarityInput = get('cip-tts-eleven-similarity');
+    const ttsElevenStyleInput = get('cip-tts-eleven-style');
+    const ttsElevenSpeakerBoostInput = get('cip-tts-eleven-speaker-boost');
     const ttsSpeedRange = get('cip-tts-speed-range');
     const ttsSpeedValue = get('cip-tts-speed-value');
     const ttsUploadName = get('cip-tts-upload-name');
@@ -707,11 +756,21 @@
 
         voiceApi = initVoiceSettings(
             {
+                ttsVendorSelect,
+                ttsVendorGroups,
                 ttsKeyInput,
                 ttsEndpointInput,
                 ttsEndpointLabel,
                 ttsModelInput,
                 ttsVoiceInput,
+                ttsElevenApiKeyInput,
+                ttsElevenVoiceIdInput,
+                ttsElevenModelIdInput,
+                ttsElevenLatencyInput,
+                ttsElevenStabilityInput,
+                ttsElevenSimilarityInput,
+                ttsElevenStyleInput,
+                ttsElevenSpeakerBoostInput,
                 ttsSpeedRange,
                 ttsSpeedValue,
                 ttsUploadName,

--- a/setting/tts/apiDocs.js
+++ b/setting/tts/apiDocs.js
@@ -12,3 +12,22 @@ Body:
   "speed": 1
 }
 接口返回音频二进制流，可用于即时播放。`;
+
+export const ELEVEN_LABS_TTS_API_DOC = `ElevenLabs 文本转语音接口使用说明：
+POST {baseUrl}/v1/text-to-speech/{voice_id}
+Headers:
+  xi-api-key: <API Key>
+  Content-Type: application/json
+  Accept: audio/mpeg
+Body:
+{
+  "text": "待合成的文本",
+  "model_id": "eleven_multilingual_v2",
+  "voice_settings": {
+    "stability": 0.5,
+    "similarity_boost": 0.5,
+    "style": 0,
+    "use_speaker_boost": false
+  }
+}
+接口返回音频二进制流 (MPEG)，可用于即时播放。`;

--- a/setting/tts/constants.js
+++ b/setting/tts/constants.js
@@ -1,4 +1,13 @@
+export const TTS_VENDORS = {
+    SILICON_FLOW: 'silicon_flow',
+    ELEVEN_LABS: 'elevenlabs',
+};
+
+export const DEFAULT_TTS_VENDOR = TTS_VENDORS.SILICON_FLOW;
 export const DEFAULT_TTS_ENDPOINT = 'https://api.siliconflow.cn/v1';
 export const DEFAULT_TTS_MODEL = 'FunAudioLLM/CosyVoice2-0.5B';
 export const DEFAULT_TTS_VOICE = 'FunAudioLLM/CosyVoice2-0.5B:alex';
 export const DEFAULT_TTS_SPEED = 1;
+
+export const DEFAULT_ELEVENLABS_BASE_URL = 'https://api.elevenlabs.io';
+export const DEFAULT_ELEVENLABS_MODEL_ID = 'eleven_multilingual_v2';

--- a/setting/tts/elevenlabs.js
+++ b/setting/tts/elevenlabs.js
@@ -1,0 +1,114 @@
+import {
+    DEFAULT_ELEVENLABS_BASE_URL,
+    DEFAULT_ELEVENLABS_MODEL_ID,
+} from './constants.js';
+
+function clamp(value, min, max) {
+    if (typeof value !== 'number' || Number.isNaN(value)) return undefined;
+    return Math.min(max, Math.max(min, value));
+}
+
+function sanitizeNumber(value, min, max, precision = null) {
+    if (typeof value === 'string' && value.trim() !== '') {
+        const parsed = Number(value);
+        if (!Number.isNaN(parsed)) value = parsed;
+    }
+    if (typeof value !== 'number' || Number.isNaN(value)) return undefined;
+    let next = clamp(value, min, max);
+    if (precision != null) {
+        const factor = 10 ** precision;
+        next = Math.round(next * factor) / factor;
+    }
+    return next;
+}
+
+export async function requestElevenLabsTTS(fetchImpl, text, options = {}) {
+    if (!fetchImpl) throw new Error('浏览器不支持 fetch');
+    const payloadText = (text || '').trim();
+    if (!payloadText) throw new Error('语音内容不能为空');
+
+    const apiKey = (options.apiKey || '').trim();
+    if (!apiKey) throw new Error('未提供 ElevenLabs API Key');
+    const voiceId = (options.voiceId || '').trim();
+    if (!voiceId) throw new Error('未提供 ElevenLabs Voice ID');
+
+    const baseUrl = (options.baseUrl || DEFAULT_ELEVENLABS_BASE_URL).replace(/\/$/, '');
+    const endpoint = `${baseUrl}/v1/text-to-speech/${encodeURIComponent(voiceId)}`;
+
+    const body = {
+        text: payloadText,
+    };
+
+    const modelId = (options.modelId || '').trim();
+    if (modelId) {
+        body.model_id = modelId;
+    } else {
+        body.model_id = DEFAULT_ELEVENLABS_MODEL_ID;
+    }
+
+    const latency = sanitizeNumber(options.optimizeStreamingLatency, 0, 4);
+    if (typeof latency === 'number') {
+        body.optimize_streaming_latency = Math.round(latency);
+    }
+
+    const stability = sanitizeNumber(options.stability, 0, 1, 2);
+    const similarity = sanitizeNumber(options.similarityBoost, 0, 1, 2);
+    const style = sanitizeNumber(options.style, 0, 100, 0);
+    const speakerBoost =
+        typeof options.useSpeakerBoost === 'boolean'
+            ? options.useSpeakerBoost
+            : undefined;
+
+    const voiceSettings = {};
+    if (typeof stability === 'number') voiceSettings.stability = stability;
+    if (typeof similarity === 'number')
+        voiceSettings.similarity_boost = similarity;
+    if (typeof style === 'number') voiceSettings.style = style;
+    if (typeof speakerBoost === 'boolean')
+        voiceSettings.use_speaker_boost = speakerBoost;
+    if (Object.keys(voiceSettings).length) {
+        body.voice_settings = voiceSettings;
+    }
+
+    const res = await fetchImpl(endpoint, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            Accept: 'audio/mpeg',
+            'xi-api-key': apiKey,
+        },
+        body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+        throw new Error(`ElevenLabs 请求失败 (HTTP ${res.status}): ${await res.text()}`);
+    }
+
+    return await res.blob();
+}
+
+export async function verifyElevenLabsConfig(fetchImpl, options = {}) {
+    if (!fetchImpl) throw new Error('浏览器不支持 fetch');
+    const apiKey = (options.apiKey || '').trim();
+    if (!apiKey) throw new Error('未提供 ElevenLabs API Key');
+    const voiceId = (options.voiceId || '').trim();
+    if (!voiceId) throw new Error('未提供 ElevenLabs Voice ID');
+    const baseUrl = (options.baseUrl || DEFAULT_ELEVENLABS_BASE_URL).replace(/\/$/, '');
+    const endpoint = `${baseUrl}/v1/voices/${encodeURIComponent(voiceId)}`;
+
+    const res = await fetchImpl(endpoint, {
+        method: 'GET',
+        headers: {
+            Accept: 'application/json',
+            'xi-api-key': apiKey,
+        },
+    });
+
+    if (!res.ok) {
+        throw new Error(
+            `ElevenLabs 校验失败 (HTTP ${res.status}): ${await res.text()}`,
+        );
+    }
+
+    return await res.json();
+}

--- a/setting/voice/index.js
+++ b/setting/voice/index.js
@@ -3,8 +3,19 @@ import {
     DEFAULT_TTS_MODEL,
     DEFAULT_TTS_VOICE,
     DEFAULT_TTS_SPEED,
+    DEFAULT_TTS_VENDOR,
+    TTS_VENDORS,
+    DEFAULT_ELEVENLABS_MODEL_ID,
+    DEFAULT_ELEVENLABS_BASE_URL,
 } from '../tts/constants.js';
-import { SILICON_FLOW_TTS_API_DOC } from '../tts/apiDocs.js';
+import {
+    SILICON_FLOW_TTS_API_DOC,
+    ELEVEN_LABS_TTS_API_DOC,
+} from '../tts/apiDocs.js';
+import {
+    requestElevenLabsTTS,
+    verifyElevenLabsConfig,
+} from '../tts/elevenlabs.js';
 
 const voiceState = {
     elements: {},
@@ -32,84 +43,394 @@ function getDefaultEndpoint() {
     return DEFAULT_TTS_ENDPOINT;
 }
 
-function getTTSSettings() {
-    const ls = getDeps().localStorageRef;
-    let settings = null;
-    try {
-        settings = JSON.parse(ls?.getItem('cip_tts_settings_v1')) || null;
-    } catch (error) {
-        settings = null;
+function toOptionalNumber(value, min, max, options = {}) {
+    if (value === null || value === undefined) return null;
+    if (typeof value === 'string') {
+        if (!value.trim()) return null;
     }
-    if (!settings) {
-        settings = {
+    const num = Number(value);
+    if (!Number.isFinite(num)) return null;
+    let clamped = Math.min(max, Math.max(min, num));
+    if (options.integer) {
+        clamped = Math.round(clamped);
+    }
+    if (typeof options.precision === 'number') {
+        const factor = 10 ** options.precision;
+        clamped = Math.round(clamped * factor) / factor;
+    }
+    return clamped;
+}
+
+function getDefaultSettings() {
+    return {
+        vendor: DEFAULT_TTS_VENDOR,
+        siliconFlow: {
             key: '',
             endpoint: getDefaultEndpoint(),
             model: '',
             voice: '',
+        },
+        elevenLabs: {
+            apiKey: '',
+            voiceId: '',
+            modelId: '',
+            baseUrl: DEFAULT_ELEVENLABS_BASE_URL,
+            optimizeStreamingLatency: null,
+            stability: null,
+            similarityBoost: null,
+            style: null,
+            useSpeakerBoost: false,
+        },
+    };
+}
+
+function normalizeSettings(raw) {
+    const defaults = getDefaultSettings();
+    if (!raw || typeof raw !== 'object') {
+        return defaults;
+    }
+
+    if (!raw.vendor && (raw.key || raw.endpoint || raw.model || raw.voice)) {
+        return {
+            ...defaults,
+            siliconFlow: {
+                ...defaults.siliconFlow,
+                key: raw.key || '',
+                endpoint: raw.endpoint || getDefaultEndpoint(),
+                model: raw.model || '',
+                voice: raw.voice || '',
+            },
         };
     }
-    if (!settings.endpoint) settings.endpoint = getDefaultEndpoint();
-    return settings;
+
+    const result = {
+        ...defaults,
+        ...raw,
+        siliconFlow: {
+            ...defaults.siliconFlow,
+            ...(raw.siliconFlow || {}),
+        },
+        elevenLabs: {
+            ...defaults.elevenLabs,
+            ...(raw.elevenLabs || {}),
+        },
+    };
+
+    if (!result.siliconFlow.endpoint) {
+        result.siliconFlow.endpoint = getDefaultEndpoint();
+    }
+    if (!result.elevenLabs.baseUrl) {
+        result.elevenLabs.baseUrl = DEFAULT_ELEVENLABS_BASE_URL;
+    }
+
+    result.elevenLabs.optimizeStreamingLatency = toOptionalNumber(
+        result.elevenLabs.optimizeStreamingLatency,
+        0,
+        4,
+        { integer: true },
+    );
+    result.elevenLabs.stability = toOptionalNumber(
+        result.elevenLabs.stability,
+        0,
+        1,
+        { precision: 2 },
+    );
+    result.elevenLabs.similarityBoost = toOptionalNumber(
+        result.elevenLabs.similarityBoost,
+        0,
+        1,
+        { precision: 2 },
+    );
+    result.elevenLabs.style = toOptionalNumber(
+        result.elevenLabs.style,
+        0,
+        100,
+        { integer: true },
+    );
+    const speakerBoostValue = result.elevenLabs.useSpeakerBoost;
+    result.elevenLabs.useSpeakerBoost =
+        speakerBoostValue === true ||
+        speakerBoostValue === 'true' ||
+        speakerBoostValue === 1 ||
+        speakerBoostValue === '1';
+
+    if (!Object.values(TTS_VENDORS).includes(result.vendor)) {
+        result.vendor = DEFAULT_TTS_VENDOR;
+    }
+
+    return result;
+}
+
+function getTTSSettings() {
+    const ls = getDeps().localStorageRef;
+    if (!ls) return getDefaultSettings();
+    try {
+        const stored = ls.getItem('cip_tts_settings_v1');
+        if (!stored) return getDefaultSettings();
+        return normalizeSettings(JSON.parse(stored));
+    } catch (error) {
+        console.warn('读取语音设置失败，已回退到默认配置', error);
+        return getDefaultSettings();
+    }
+}
+
+function getSelectedVendorValue() {
+    return (
+        getElements().ttsVendorSelect?.value ||
+        getTTSSettings().vendor ||
+        DEFAULT_TTS_VENDOR
+    );
+}
+
+function getVendorDisplayName(vendor) {
+    switch (vendor) {
+        case TTS_VENDORS.SILICON_FLOW:
+            return '硅基流动';
+        case TTS_VENDORS.ELEVEN_LABS:
+            return 'ElevenLabs';
+        default:
+            return '未知厂商';
+    }
+}
+
+function getSpeechSpeed() {
+    const raw = Number(getElements().ttsSpeedRange?.value || DEFAULT_TTS_SPEED);
+    if (!Number.isFinite(raw)) return DEFAULT_TTS_SPEED;
+    return Math.min(4, Math.max(0.25, raw));
+}
+
+function updateVendorVisibility(vendor) {
+    const { ttsVendorConditionals = [], ttsSubtabs, ttsPanes } = getElements();
+
+    ttsVendorConditionals.forEach((node) => {
+        const target = node?.dataset?.ttsVendor;
+        if (!target) return;
+        const shouldShow = target === vendor;
+        if ('hidden' in node) {
+            node.hidden = !shouldShow;
+        } else if (node.style) {
+            node.style.display = shouldShow ? '' : 'none';
+        }
+    });
+
+    let activeTarget = null;
+    if (ttsSubtabs?.length) {
+        ttsSubtabs.forEach((btn) => {
+            const targetVendor = btn.dataset.ttsVendor;
+            const visible = !targetVendor || targetVendor === vendor;
+            btn.hidden = !visible;
+            if (visible && btn.classList.contains('active')) {
+                activeTarget = btn.dataset.subtab;
+            }
+        });
+        if (!activeTarget) {
+            const fallback = Array.from(ttsSubtabs).find((btn) => !btn.hidden);
+            if (fallback) {
+                activeTarget = fallback.dataset.subtab;
+                ttsSubtabs.forEach((btn) =>
+                    btn.classList.toggle('active', btn === fallback),
+                );
+            }
+        } else {
+            ttsSubtabs.forEach((btn) =>
+                btn.classList.toggle(
+                    'active',
+                    !btn.hidden && btn.dataset.subtab === activeTarget,
+                ),
+            );
+        }
+    }
+
+    if (!activeTarget) activeTarget = 'settings';
+
+    if (ttsPanes?.length) {
+        ttsPanes.forEach((pane) => {
+            const targetVendor = pane.dataset.ttsVendor;
+            const visible = !targetVendor || targetVendor === vendor;
+            pane.hidden = !visible;
+            const paneTarget = pane.id?.replace('cip-tts-pane-', '');
+            pane.classList.toggle('active', visible && paneTarget === activeTarget);
+        });
+    }
+
+    const { ttsEndpointLabel } = getElements();
+    if (ttsEndpointLabel) {
+        if (vendor === TTS_VENDORS.SILICON_FLOW) {
+            ttsEndpointLabel.title = SILICON_FLOW_TTS_API_DOC;
+        } else if (vendor === TTS_VENDORS.ELEVEN_LABS) {
+            ttsEndpointLabel.title = ELEVEN_LABS_TTS_API_DOC;
+        } else {
+            ttsEndpointLabel.removeAttribute('title');
+        }
+    }
 }
 
 function applyTTSSettingsToUI(settings) {
     const {
+        ttsVendorSelect,
         ttsKeyInput,
         ttsEndpointInput,
         ttsModelInput,
         ttsVoiceInput,
+        ttsElevenApiKeyInput,
+        ttsElevenVoiceIdInput,
+        ttsElevenModelIdInput,
+        ttsElevenLatencyInput,
+        ttsElevenStabilityInput,
+        ttsElevenSimilarityInput,
+        ttsElevenStyleInput,
+        ttsElevenSpeakerBoostInput,
     } = getElements();
-    if (ttsKeyInput) ttsKeyInput.value = settings.key || '';
+
+    const normalized = normalizeSettings(settings);
+    if (ttsVendorSelect) {
+        ttsVendorSelect.value = normalized.vendor || DEFAULT_TTS_VENDOR;
+    }
+
+    if (ttsKeyInput) ttsKeyInput.value = normalized.siliconFlow.key || '';
     if (ttsEndpointInput)
-        ttsEndpointInput.value = settings.endpoint || getDefaultEndpoint();
-    if (ttsModelInput && settings.model) {
-        if (
-            !ttsModelInput.options.length ||
-            !ttsModelInput.querySelector(`option[value="${settings.model}"]`)
-        ) {
-            const opt = new Option(settings.model, settings.model, true, true);
-            ttsModelInput.innerHTML = '';
-            ttsModelInput.add(opt);
+        ttsEndpointInput.value =
+            normalized.siliconFlow.endpoint || getDefaultEndpoint();
+
+    if (ttsModelInput) {
+        const model = normalized.siliconFlow.model;
+        if (model) {
+            if (
+                !ttsModelInput.options.length ||
+                !ttsModelInput.querySelector(`option[value="${model}"]`)
+            ) {
+                const opt = new Option(model, model, true, true);
+                ttsModelInput.innerHTML = '';
+                ttsModelInput.add(opt);
+            }
+            ttsModelInput.value = model;
+        } else {
+            ttsModelInput.selectedIndex = -1;
         }
-        ttsModelInput.value = settings.model;
     }
-    if (ttsVoiceInput && settings.voice) {
-        if (
-            !ttsVoiceInput.options.length ||
-            !ttsVoiceInput.querySelector(`option[value="${settings.voice}"]`)
-        ) {
-            const opt = new Option(settings.voice, settings.voice, true, true);
-            ttsVoiceInput.innerHTML = '';
-            ttsVoiceInput.add(opt);
+
+    if (ttsVoiceInput) {
+        const voice = normalized.siliconFlow.voice;
+        if (voice) {
+            if (
+                !ttsVoiceInput.options.length ||
+                !ttsVoiceInput.querySelector(`option[value="${voice}"]`)
+            ) {
+                const opt = new Option(voice, voice, true, true);
+                ttsVoiceInput.innerHTML = '';
+                ttsVoiceInput.add(opt);
+            }
+            ttsVoiceInput.value = voice;
+        } else {
+            ttsVoiceInput.selectedIndex = -1;
         }
-        ttsVoiceInput.value = settings.voice;
     }
+
+    if (ttsElevenApiKeyInput)
+        ttsElevenApiKeyInput.value = normalized.elevenLabs.apiKey || '';
+    if (ttsElevenVoiceIdInput)
+        ttsElevenVoiceIdInput.value = normalized.elevenLabs.voiceId || '';
+    if (ttsElevenModelIdInput)
+        ttsElevenModelIdInput.value = normalized.elevenLabs.modelId || '';
+
+    const latency = normalized.elevenLabs.optimizeStreamingLatency;
+    if (ttsElevenLatencyInput)
+        ttsElevenLatencyInput.value =
+            latency === null || latency === undefined ? '' : latency;
+
+    const stability = normalized.elevenLabs.stability;
+    if (ttsElevenStabilityInput)
+        ttsElevenStabilityInput.value =
+            stability === null || stability === undefined ? '' : stability;
+
+    const similarity = normalized.elevenLabs.similarityBoost;
+    if (ttsElevenSimilarityInput)
+        ttsElevenSimilarityInput.value =
+            similarity === null || similarity === undefined ? '' : similarity;
+
+    const style = normalized.elevenLabs.style;
+    if (ttsElevenStyleInput)
+        ttsElevenStyleInput.value =
+            style === null || style === undefined ? '' : style;
+
+    if (ttsElevenSpeakerBoostInput) {
+        ttsElevenSpeakerBoostInput.checked =
+            normalized.elevenLabs.useSpeakerBoost || false;
+    }
+
+    updateVendorVisibility(normalized.vendor || DEFAULT_TTS_VENDOR);
 }
 
 function readTTSSettingsFromUI() {
     const {
+        ttsVendorSelect,
         ttsKeyInput,
         ttsEndpointInput,
         ttsModelInput,
         ttsVoiceInput,
+        ttsElevenApiKeyInput,
+        ttsElevenVoiceIdInput,
+        ttsElevenModelIdInput,
+        ttsElevenLatencyInput,
+        ttsElevenStabilityInput,
+        ttsElevenSimilarityInput,
+        ttsElevenStyleInput,
+        ttsElevenSpeakerBoostInput,
     } = getElements();
-    return {
-        key: (ttsKeyInput?.value || '').trim(),
-        endpoint:
-            (ttsEndpointInput?.value || '').trim() || getDefaultEndpoint(),
-        model: (ttsModelInput?.value || '').trim(),
-        voice: (ttsVoiceInput?.value || '').trim(),
+
+    const nextSettings = {
+        vendor: ttsVendorSelect?.value || DEFAULT_TTS_VENDOR,
+        siliconFlow: {
+            key: (ttsKeyInput?.value || '').trim(),
+            endpoint:
+                (ttsEndpointInput?.value || '').trim() || getDefaultEndpoint(),
+            model: (ttsModelInput?.value || '').trim(),
+            voice: (ttsVoiceInput?.value || '').trim(),
+        },
+        elevenLabs: {
+            apiKey: (ttsElevenApiKeyInput?.value || '').trim(),
+            voiceId: (ttsElevenVoiceIdInput?.value || '').trim(),
+            modelId: (ttsElevenModelIdInput?.value || '').trim(),
+            baseUrl: DEFAULT_ELEVENLABS_BASE_URL,
+            optimizeStreamingLatency: toOptionalNumber(
+                ttsElevenLatencyInput?.value,
+                0,
+                4,
+                { integer: true },
+            ),
+            stability: toOptionalNumber(
+                ttsElevenStabilityInput?.value,
+                0,
+                1,
+                { precision: 2 },
+            ),
+            similarityBoost: toOptionalNumber(
+                ttsElevenSimilarityInput?.value,
+                0,
+                1,
+                { precision: 2 },
+            ),
+            style: toOptionalNumber(
+                ttsElevenStyleInput?.value,
+                0,
+                100,
+                { integer: true },
+            ),
+            useSpeakerBoost: Boolean(ttsElevenSpeakerBoostInput?.checked),
+        },
     };
+
+    return normalizeSettings(nextSettings);
 }
 
 function saveTTSSettings(settings) {
     try {
         getDeps().localStorageRef?.setItem(
             'cip_tts_settings_v1',
-            JSON.stringify(settings),
+            JSON.stringify(normalizeSettings(settings)),
         );
     } catch (error) {
-        console.error('保存语音设置失败', error);
+        console.error('保存语音设置失败 (localStorage)', error);
     }
 }
 
@@ -125,15 +446,14 @@ async function fetchSiliconFlowTTS(text, settings) {
     const endpoint = base.endsWith('/audio/speech')
         ? base
         : `${base.replace(/\/$/, '')}/audio/speech`;
-    if (!settings.key) throw new Error('未配置硅基流动API Key');
+    if (!settings.key) throw new Error('请先填写硅基流动 API Key');
+
     const body = {
         model: settings.model || DEFAULT_TTS_MODEL,
         voice: settings.voice || DEFAULT_TTS_VOICE,
         input: text,
         format: 'mp3',
-        speed:
-            parseFloat(getElements().ttsSpeedRange?.value || DEFAULT_TTS_SPEED) ||
-            DEFAULT_TTS_SPEED,
+        speed: getSpeechSpeed(),
     };
     const fetchImpl = getDeps().fetchRef;
     if (!fetchImpl) throw new Error('浏览器不支持 fetch');
@@ -146,9 +466,19 @@ async function fetchSiliconFlowTTS(text, settings) {
         body: JSON.stringify(body),
     });
     if (!res.ok) {
-        throw new Error(`HTTP ${res.status}: ${await res.text()}`);
+        throw new Error(
+            `硅基流动请求失败 (HTTP ${res.status}): ${await res.text()}`,
+        );
     }
     return await res.blob();
+}
+
+async function fetchElevenLabsTTS(text, settings) {
+    const fetchImpl = getDeps().fetchRef;
+    return await requestElevenLabsTTS(fetchImpl, text, {
+        ...settings,
+        baseUrl: settings.baseUrl || DEFAULT_ELEVENLABS_BASE_URL,
+    });
 }
 
 function playNextAudio() {
@@ -208,10 +538,35 @@ function playImmediateBlob(blob) {
 
 async function synthesizeTTS(text, playOnReady = true) {
     const settings = readTTSSettingsFromUI();
-    if (!settings.key) throw new Error('请先填写硅基流动 API Key');
-    if (!settings.model) settings.model = DEFAULT_TTS_MODEL;
-    if (!settings.voice) settings.voice = DEFAULT_TTS_VOICE;
-    const blob = await fetchSiliconFlowTTS(text, settings);
+    const vendor = settings.vendor || DEFAULT_TTS_VENDOR;
+    let blob = null;
+
+    if (vendor === TTS_VENDORS.SILICON_FLOW) {
+        const vendorSettings = { ...settings.siliconFlow };
+        if (!vendorSettings.key) {
+            throw new Error('请先填写硅基流动 API Key');
+        }
+        if (!vendorSettings.model) vendorSettings.model = DEFAULT_TTS_MODEL;
+        if (!vendorSettings.voice) vendorSettings.voice = DEFAULT_TTS_VOICE;
+        blob = await fetchSiliconFlowTTS(text, vendorSettings);
+    } else if (vendor === TTS_VENDORS.ELEVEN_LABS) {
+        const vendorSettings = { ...settings.elevenLabs };
+        vendorSettings.baseUrl =
+            vendorSettings.baseUrl || DEFAULT_ELEVENLABS_BASE_URL;
+        if (!vendorSettings.apiKey) {
+            throw new Error('请先填写 ElevenLabs API Key');
+        }
+        if (!vendorSettings.voiceId) {
+            throw new Error('请先填写 ElevenLabs Voice ID');
+        }
+        if (!vendorSettings.modelId) {
+            vendorSettings.modelId = DEFAULT_ELEVENLABS_MODEL_ID;
+        }
+        blob = await fetchElevenLabsTTS(text, vendorSettings);
+    } else {
+        throw new Error('未知的语音厂商，请重新选择');
+    }
+
     if (playOnReady) {
         voiceState.queue.push(blob);
         if (!voiceState.isPlaying) playNextAudio();
@@ -243,6 +598,7 @@ function setupModelChangeHandler() {
     const { ttsModelInput, ttsVoiceInput, ttsKeyInput } = getElements();
     if (!ttsModelInput || !ttsVoiceInput) return;
     ttsModelInput.addEventListener('change', async () => {
+        if (getSelectedVendorValue() !== TTS_VENDORS.SILICON_FLOW) return;
         const doc = getDeps().documentRef;
         if (!doc) return;
         ttsVoiceInput.innerHTML = '';
@@ -346,6 +702,10 @@ function setupUploadHandlers() {
     if (ttsUploadBtn) {
         ttsUploadBtn.addEventListener('click', async () => {
             try {
+                if (getSelectedVendorValue() !== TTS_VENDORS.SILICON_FLOW) {
+                    updateTTSStatus('上传音色仅支持硅基流动，请切换厂商', true);
+                    return;
+                }
                 if (!ttsKeyInput?.value) {
                     throw new Error('请先填写硅基流动 API Key');
                 }
@@ -394,6 +754,10 @@ function setupDeleteVoiceHandler() {
     if (!ttsVoiceDeleteBtn || !ttsVoiceInput) return;
     ttsVoiceDeleteBtn.addEventListener('click', async () => {
         try {
+            if (getSelectedVendorValue() !== TTS_VENDORS.SILICON_FLOW) {
+                updateTTSStatus('删除音色仅支持硅基流动，请切换厂商', true);
+                return;
+            }
             const val = ttsVoiceInput.value || '';
             if (!val) {
                 updateTTSStatus('请先选择要删除的音色', true);
@@ -438,6 +802,10 @@ function setupRefreshHandler() {
     const { ttsRefreshVoicesBtn, ttsModelInput } = getElements();
     if (ttsRefreshVoicesBtn) {
         ttsRefreshVoicesBtn.addEventListener('click', () => {
+            if (getSelectedVendorValue() !== TTS_VENDORS.SILICON_FLOW) {
+                updateTTSStatus('刷新音色仅支持硅基流动，请切换厂商', true);
+                return;
+            }
             ttsModelInput?.dispatchEvent(new Event('change'));
             updateTTSStatus('音色已刷新');
         });
@@ -446,87 +814,113 @@ function setupRefreshHandler() {
 
 function setupCheckHandler() {
     const { ttsCheckBtn, ttsModelInput, ttsVoiceInput } = getElements();
-    if (!ttsCheckBtn || !ttsModelInput || !ttsVoiceInput) return;
+    if (!ttsCheckBtn) return;
     ttsCheckBtn.addEventListener('click', async () => {
         const settings = readTTSSettingsFromUI();
+        const vendor = settings.vendor || DEFAULT_TTS_VENDOR;
         try {
-            updateTTSStatus('连接中...');
-            const models = [
-                'FunAudioLLM/CosyVoice2-0.5B',
-                'fnlp/MOSS-TTSD-v0.5',
-            ];
-            ttsModelInput.innerHTML = '';
-            models.forEach((m) => ttsModelInput.appendChild(new Option(m, m)));
-            ttsModelInput.value = models[0];
-            ttsVoiceInput.innerHTML = '';
-            const doc = getDeps().documentRef;
-            if (!doc) return;
-            const cosyGroup = doc.createElement('optgroup');
-            cosyGroup.label = '预设音色 (CosyVoice)';
-            ['alex', 'benjamin', 'charles', 'david', 'anna', 'bella', 'claire', 'diana']
-                .map((name) => ({
-                    value: `${models[0]}:${name}`,
-                    label: name,
-                }))
-                .forEach(({ value, label }) =>
-                    cosyGroup.appendChild(new Option(label, value)),
-                );
-            ttsVoiceInput.appendChild(cosyGroup);
-            const mossGroup = doc.createElement('optgroup');
-            mossGroup.label = '预设音色 (MOSS)';
-            ['alex', 'anna', 'bella', 'benjamin', 'charles', 'claire', 'david', 'diana']
-                .map((name) => ({
-                    value: `${models[1]}:${name}`,
-                    label: name,
-                }))
-                .forEach(({ value, label }) =>
-                    mossGroup.appendChild(new Option(label, value)),
-                );
-            ttsVoiceInput.appendChild(mossGroup);
-            const apiKey = settings.key;
-            if (apiKey) {
-                try {
-                    const res = await getDeps().fetchRef(
-                        'https://api.siliconflow.cn/v1/audio/voice/list',
-                        {
-                            method: 'GET',
-                            headers: {
-                                Authorization: `Bearer ${apiKey}`,
-                                'Content-Type': 'application/json',
-                            },
-                        },
-                    );
-                    if (res.ok) {
-                        const data = await res.json();
-                        const arr = data?.result || data?.results || [];
-                        const list = (Array.isArray(arr) ? arr : []).map((item) => ({
-                            value: item?.uri || item?.id || item?.voice_id,
-                            label:
-                                (item?.name ||
-                                    item?.customName ||
-                                    item?.custom_name ||
-                                    '自定义音色') + ' (自定义)',
-                        }));
-                        if (list.length) {
-                            const customGroup = doc.createElement('optgroup');
-                            customGroup.label = '自定义音色';
-                            list
-                                .filter((item) => item.value)
-                                .forEach(({ value, label }) =>
-                                    customGroup.appendChild(
-                                        new Option(label, value),
-                                    ),
-                                );
-                            ttsVoiceInput.appendChild(customGroup);
-                        }
-                    }
-                } catch (error) {
-                    console.warn('获取自定义音色失败', error);
+            if (vendor === TTS_VENDORS.SILICON_FLOW) {
+                if (!ttsModelInput || !ttsVoiceInput) {
+                    throw new Error('当前环境缺少模型或音色选择控件');
                 }
+                updateTTSStatus('正在连接硅基流动...');
+                const models = [
+                    'FunAudioLLM/CosyVoice2-0.5B',
+                    'fnlp/MOSS-TTSD-v0.5',
+                ];
+                ttsModelInput.innerHTML = '';
+                models.forEach((m) => ttsModelInput.appendChild(new Option(m, m)));
+                ttsModelInput.value = models[0];
+                ttsVoiceInput.innerHTML = '';
+                const doc = getDeps().documentRef;
+                if (!doc) throw new Error('无法访问文档对象');
+                const cosyGroup = doc.createElement('optgroup');
+                cosyGroup.label = '预设音色 (CosyVoice)';
+                ['alex', 'benjamin', 'charles', 'david', 'anna', 'bella', 'claire', 'diana']
+                    .map((name) => ({
+                        value: `${models[0]}:${name}`,
+                        label: name,
+                    }))
+                    .forEach(({ value, label }) =>
+                        cosyGroup.appendChild(new Option(label, value)),
+                    );
+                ttsVoiceInput.appendChild(cosyGroup);
+                const mossGroup = doc.createElement('optgroup');
+                mossGroup.label = '预设音色 (MOSS)';
+                ['alex', 'anna', 'bella', 'benjamin', 'charles', 'claire', 'david', 'diana']
+                    .map((name) => ({
+                        value: `${models[1]}:${name}`,
+                        label: name,
+                    }))
+                    .forEach(({ value, label }) =>
+                        mossGroup.appendChild(new Option(label, value)),
+                    );
+                ttsVoiceInput.appendChild(mossGroup);
+                const apiKey = settings.siliconFlow?.key;
+                if (apiKey) {
+                    try {
+                        const res = await getDeps().fetchRef(
+                            'https://api.siliconflow.cn/v1/audio/voice/list',
+                            {
+                                method: 'GET',
+                                headers: {
+                                    Authorization: `Bearer ${apiKey}`,
+                                    'Content-Type': 'application/json',
+                                },
+                            },
+                        );
+                        if (res.ok) {
+                            const data = await res.json();
+                            const arr = data?.result || data?.results || [];
+                            const list = (Array.isArray(arr) ? arr : []).map((item) => ({
+                                value: item?.uri || item?.id || item?.voice_id,
+                                label:
+                                    (item?.name ||
+                                        item?.customName ||
+                                        item?.custom_name ||
+                                        '自定义音色') + ' (自定义)',
+                            }));
+                            if (list.length) {
+                                const customGroup = doc.createElement('optgroup');
+                                customGroup.label = '自定义音色';
+                                list
+                                    .filter((item) => item.value)
+                                    .forEach(({ value, label }) =>
+                                        customGroup.appendChild(
+                                            new Option(label, value),
+                                        ),
+                                    );
+                                ttsVoiceInput.appendChild(customGroup);
+                            }
+                        }
+                    } catch (error) {
+                        console.warn('获取自定义音色失败', error);
+                    }
+                }
+                if (ttsVoiceInput.options.length) ttsVoiceInput.selectedIndex = 0;
+                saveTTSSettings(readTTSSettingsFromUI());
+                updateTTSStatus('连接成功，已自动填充模型与音色');
+            } else if (vendor === TTS_VENDORS.ELEVEN_LABS) {
+                const fetchImpl = getDeps().fetchRef;
+                if (!fetchImpl) throw new Error('浏览器不支持 fetch');
+                const { elevenLabs } = settings;
+                if (!elevenLabs.apiKey) {
+                    throw new Error('请先填写 ElevenLabs API Key');
+                }
+                if (!elevenLabs.voiceId) {
+                    throw new Error('请先填写 ElevenLabs Voice ID');
+                }
+                updateTTSStatus('正在验证 ElevenLabs 配置...');
+                await verifyElevenLabsConfig(fetchImpl, {
+                    apiKey: elevenLabs.apiKey,
+                    voiceId: elevenLabs.voiceId,
+                    baseUrl: elevenLabs.baseUrl,
+                });
+                saveTTSSettings(settings);
+                updateTTSStatus('连接成功，ElevenLabs 配置有效');
+            } else {
+                throw new Error('未知的语音厂商，无法连接');
             }
-            if (ttsVoiceInput.options.length) ttsVoiceInput.selectedIndex = 0;
-            saveTTSSettings(readTTSSettingsFromUI());
-            updateTTSStatus('连接成功，已自动填充模型与音色');
         } catch (error) {
             updateTTSStatus(`连接失败: ${error.message || error}`, true);
         }
@@ -538,17 +932,34 @@ function setupTabs() {
     if (!ttsSubtabs || !ttsPanes) return;
     ttsSubtabs.forEach((btn) => {
         btn.addEventListener('click', () => {
+            if (btn.hidden) return;
             const target = btn.dataset.subtab;
             ttsSubtabs.forEach((b) =>
-                b.classList.toggle('active', b === btn),
+                b.classList.toggle('active', !b.hidden && b === btn),
             );
             ttsPanes.forEach((pane) =>
                 pane.classList.toggle(
                     'active',
-                    pane.id === `cip-tts-pane-${target}`,
+                    !pane.hidden && pane.id === `cip-tts-pane-${target}`,
                 ),
             );
         });
+    });
+}
+
+function setupVendorChangeHandler() {
+    const { ttsVendorSelect, ttsModelInput } = getElements();
+    if (!ttsVendorSelect) return;
+    ttsVendorSelect.addEventListener('change', () => {
+        const next = readTTSSettingsFromUI();
+        applyTTSSettingsToUI(next);
+        saveTTSSettings(next);
+        updateTTSStatus(
+            `已切换到 ${getVendorDisplayName(next.vendor)}, 请完善对应配置`,
+        );
+        if (next.vendor === TTS_VENDORS.SILICON_FLOW) {
+            ttsModelInput?.dispatchEvent(new Event('change'));
+        }
     });
 }
 
@@ -588,17 +999,33 @@ export function initVoiceSettings(elements, dependencies = {}) {
     voiceState.elements = elements || {};
     voiceState.dependencies = { ...voiceState.dependencies, ...dependencies };
 
-    const { ttsEndpointInput, ttsEndpointLabel, ttsModelInput } = getElements();
+    const doc = getDeps().documentRef;
+    if (doc) {
+        const conditionalSet = new Set([
+            ...(Array.isArray(voiceState.elements.ttsVendorGroups)
+                ? voiceState.elements.ttsVendorGroups
+                : []),
+            ...Array.from(doc.querySelectorAll('[data-tts-vendor]')),
+        ]);
+        voiceState.elements.ttsVendorConditionals = Array.from(conditionalSet);
+    } else if (!voiceState.elements.ttsVendorConditionals) {
+        voiceState.elements.ttsVendorConditionals = Array.isArray(
+            voiceState.elements.ttsVendorGroups,
+        )
+            ? voiceState.elements.ttsVendorGroups
+            : [];
+    }
+
+    const { ttsEndpointInput, ttsModelInput } = getElements();
     if (ttsEndpointInput && !ttsEndpointInput.value) {
         ttsEndpointInput.value = getDefaultEndpoint();
     }
-    if (ttsEndpointLabel) {
-        ttsEndpointLabel.title = SILICON_FLOW_TTS_API_DOC;
-    }
 
-    applyTTSSettingsToUI(getTTSSettings());
+    const initialSettings = getTTSSettings();
+    applyTTSSettingsToUI(initialSettings);
 
     setupTabs();
+    setupVendorChangeHandler();
     setupSaveAndTest();
     setupSpeedControls();
     setupModelChangeHandler();
@@ -607,7 +1034,9 @@ export function initVoiceSettings(elements, dependencies = {}) {
     setupRefreshHandler();
     setupCheckHandler();
 
-    ttsModelInput?.dispatchEvent(new Event('change'));
+    if (initialSettings.vendor === TTS_VENDORS.SILICON_FLOW) {
+        ttsModelInput?.dispatchEvent(new Event('change'));
+    }
 
     return {
         synthesizeTTS,

--- a/style.css
+++ b/style.css
@@ -1379,6 +1379,12 @@ emoji-picker {
     align-items: center;
     margin-bottom: 10px;
 }
+.cip-tts-vendor-group {
+    display: contents;
+}
+.cip-tts-vendor-group[hidden] {
+    display: none;
+}
 .cip-tts-grid label {
     font-size: 14px;
     color: var(--cip-text-color);
@@ -1391,6 +1397,11 @@ emoji-picker {
     background-color: var(--cip-input-bg-color);
     font-size: 14px;
     color: var(--cip-text-color);
+}
+.cip-tts-checkbox-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
 }
 .cip-tts-subsection {
     margin: 10px 0;


### PR DESCRIPTION
## Summary
- add a vendor selector to the TTS settings UI with vendor-specific fields and hide Silicon Flow-only actions when appropriate
- extend TTS state management to persist per-vendor credentials, call the new ElevenLabs client, and improve validation/error feedback
- document ElevenLabs API usage and add layout styles plus a reusable ElevenLabs request/verification helper

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f09fb8041c8322a0e1300742bd217a