### PR TITLE
Lazy load ElevenLabs provider

### DIFF
--- a/script.js
+++ b/script.js
@@ -335,11 +335,14 @@
 
                     <div id="cip-tts-pane-settings" class="cip-tts-pane active">
                         <div class="cip-tts-grid">
+                            <label for="cip-tts-vendor">厂商</label>
+                            <select id="cip-tts-vendor">
+                                <option value="siliconflow">硅基流动</option>
+                                <option value="elevenlabs">ElevenLabs</option>
+                            </select>
+
                             <label for="cip-tts-key">API</label>
                             <input type="password" id="cip-tts-key" placeholder="填写硅基流动 API Key">
-
-                            <label for="cip-tts-endpoint">API端点</label>
-                            <input type="text" id="cip-tts-endpoint" placeholder="自动设置，无需填写">
 
                             <label for="cip-tts-model">模型</label>
                             <select id="cip-tts-model"></select>
@@ -503,11 +506,10 @@
     const restoreDefaultsBtn = get('cip-restore-defaults-btn');
     // --- 新增: 语音设置元素引用 ---
     // provider/MiniMax 已移除
+    const ttsVendorSelect = get('cip-tts-vendor');
     const ttsKeyInput = get('cip-tts-key');
     const ttsModelInput = get('cip-tts-model');
     const ttsVoiceInput = get('cip-tts-voice');
-    const ttsEndpointInput = get('cip-tts-endpoint');
-    const ttsEndpointLabel = document.querySelector('label[for="cip-tts-endpoint"]');
     const ttsSpeedRange = get('cip-tts-speed-range');
     const ttsSpeedValue = get('cip-tts-speed-value');
     const ttsUploadName = get('cip-tts-upload-name');
@@ -707,9 +709,8 @@
 
         voiceApi = initVoiceSettings(
             {
+                ttsVendorSelect,
                 ttsKeyInput,
-                ttsEndpointInput,
-                ttsEndpointLabel,
                 ttsModelInput,
                 ttsVoiceInput,
                 ttsSpeedRange,

--- a/setting/tts/constants.js
+++ b/setting/tts/constants.js
@@ -1,4 +1,22 @@
-export const DEFAULT_TTS_ENDPOINT = 'https://api.siliconflow.cn/v1';
+export const TTS_VENDORS = [
+    {
+        id: 'siliconflow',
+        name: '硅基流动',
+        endpoint: 'https://api.siliconflow.cn/v1',
+    },
+    {
+        id: 'elevenlabs',
+        name: 'ElevenLabs',
+        endpoint: 'https://api.elevenlabs.io/v1',
+    },
+];
+
+export const DEFAULT_TTS_VENDOR = 'siliconflow';
+
+export const DEFAULT_TTS_ENDPOINT = TTS_VENDORS.find(
+    (vendor) => vendor.id === DEFAULT_TTS_VENDOR,
+)?.endpoint || 'https://api.siliconflow.cn/v1';
+
 export const DEFAULT_TTS_MODEL = 'FunAudioLLM/CosyVoice2-0.5B';
 export const DEFAULT_TTS_VOICE = 'FunAudioLLM/CosyVoice2-0.5B:alex';
 export const DEFAULT_TTS_SPEED = 1;

--- a/setting/tts/setting/tts/elevenlabs.js
+++ b/setting/tts/setting/tts/elevenlabs.js
@@ -1,114 +1,132 @@
-import {
-    DEFAULT_ELEVENLABS_BASE_URL,
-    DEFAULT_ELEVENLABS_MODEL_ID,
-} from './constants.js';
+// ===== ElevenLabs TTS Provider for 胡萝卜插件 =====
 
-function clamp(value, min, max) {
-    if (typeof value !== 'number' || Number.isNaN(value)) return undefined;
-    return Math.min(max, Math.max(min, value));
-}
+// tts/providers/elevenlabs.js
+export default class ElevenLabsProvider {
+    constructor({ fetch: fetchImpl } = {}) {
+        this.name = 'elevenlabs';
+        this.displayName = 'ElevenLabs';
+        this.apiEndpoint = 'https://api.elevenlabs.io/v1'; // 固定端点
+        this.fetchImpl =
+            fetchImpl || (typeof fetch !== 'undefined' ? fetch : null);
 
-function sanitizeNumber(value, min, max, precision = null) {
-    if (typeof value === 'string' && value.trim() !== '') {
-        const parsed = Number(value);
-        if (!Number.isNaN(parsed)) value = parsed;
-    }
-    if (typeof value !== 'number' || Number.isNaN(value)) return undefined;
-    let next = clamp(value, min, max);
-    if (precision != null) {
-        const factor = 10 ** precision;
-        next = Math.round(next * factor) / factor;
-    }
-    return next;
-}
-
-export async function requestElevenLabsTTS(fetchImpl, text, options = {}) {
-    if (!fetchImpl) throw new Error('浏览器不支持 fetch');
-    const payloadText = (text || '').trim();
-    if (!payloadText) throw new Error('语音内容不能为空');
-
-    const apiKey = (options.apiKey || '').trim();
-    if (!apiKey) throw new Error('未提供 ElevenLabs API Key');
-    const voiceId = (options.voiceId || '').trim();
-    if (!voiceId) throw new Error('未提供 ElevenLabs Voice ID');
-
-    const baseUrl = (options.baseUrl || DEFAULT_ELEVENLABS_BASE_URL).replace(/\/$/, '');
-    const endpoint = `${baseUrl}/v1/text-to-speech/${encodeURIComponent(voiceId)}`;
-
-    const body = {
-        text: payloadText,
-    };
-
-    const modelId = (options.modelId || '').trim();
-    if (modelId) {
-        body.model_id = modelId;
-    } else {
-        body.model_id = DEFAULT_ELEVENLABS_MODEL_ID;
+        // 默认设置
+        this.defaultSettings = {
+            stability: 0.75,
+            similarity_boost: 0.75,
+            style_exaggeration: 0.0,
+            speaker_boost: true,
+            speed: 1.0,
+        };
     }
 
-    const latency = sanitizeNumber(options.optimizeStreamingLatency, 0, 4);
-    if (typeof latency === 'number') {
-        body.optimize_streaming_latency = Math.round(latency);
-    }
+    // 统一接口：合成语音
+    async synthesize(text, settings) {
+        const apiKey = settings.key;
+        const voiceId = settings.voice || 'EXAVITQu4vr4xnSDxMaL';
+        const modelId = settings.model || 'eleven_multilingual_v2';
+        
+        // 确保 stability 值是允许的值之一
+        let stability = parseFloat(settings.stability) || 0.5;
+        
+        // 将 stability 映射到允许的值
+        if (stability <= 0.25) {
+            stability = 0.0;  // Creative
+        } else if (stability <= 0.75) {
+            stability = 0.5;  // Natural
+        } else {
+            stability = 1.0;  // Robust
+        }
+        
+        // 确保 similarity_boost 在有效范围内
+        const similarity_boost = Math.max(0, Math.min(1, parseFloat(settings.similarity) || 0.75));
+        
+        const fetchFn = this.fetchImpl;
+        if (typeof fetchFn !== 'function') {
+            throw new Error('当前环境不支持 fetch');
+        }
 
-    const stability = sanitizeNumber(options.stability, 0, 1, 2);
-    const similarity = sanitizeNumber(options.similarityBoost, 0, 1, 2);
-    const style = sanitizeNumber(options.style, 0, 100, 0);
-    const speakerBoost =
-        typeof options.useSpeakerBoost === 'boolean'
-            ? options.useSpeakerBoost
-            : undefined;
-
-    const voiceSettings = {};
-    if (typeof stability === 'number') voiceSettings.stability = stability;
-    if (typeof similarity === 'number')
-        voiceSettings.similarity_boost = similarity;
-    if (typeof style === 'number') voiceSettings.style = style;
-    if (typeof speakerBoost === 'boolean')
-        voiceSettings.use_speaker_boost = speakerBoost;
-    if (Object.keys(voiceSettings).length) {
-        body.voice_settings = voiceSettings;
-    }
-
-    const res = await fetchImpl(endpoint, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            Accept: 'audio/mpeg',
-            'xi-api-key': apiKey,
-        },
-        body: JSON.stringify(body),
-    });
-
-    if (!res.ok) {
-        throw new Error(`ElevenLabs 请求失败 (HTTP ${res.status}): ${await res.text()}`);
-    }
-
-    return await res.blob();
-}
-
-export async function verifyElevenLabsConfig(fetchImpl, options = {}) {
-    if (!fetchImpl) throw new Error('浏览器不支持 fetch');
-    const apiKey = (options.apiKey || '').trim();
-    if (!apiKey) throw new Error('未提供 ElevenLabs API Key');
-    const voiceId = (options.voiceId || '').trim();
-    if (!voiceId) throw new Error('未提供 ElevenLabs Voice ID');
-    const baseUrl = (options.baseUrl || DEFAULT_ELEVENLABS_BASE_URL).replace(/\/$/, '');
-    const endpoint = `${baseUrl}/v1/voices/${encodeURIComponent(voiceId)}`;
-
-    const res = await fetchImpl(endpoint, {
-        method: 'GET',
-        headers: {
-            Accept: 'application/json',
-            'xi-api-key': apiKey,
-        },
-    });
-
-    if (!res.ok) {
-        throw new Error(
-            `ElevenLabs 校验失败 (HTTP ${res.status}): ${await res.text()}`,
+        const response = await fetchFn(
+            `${this.apiEndpoint}/text-to-speech/${voiceId}`,
+            {
+                method: 'POST',
+                headers: {
+                    'Accept': 'audio/mpeg',
+                    'Content-Type': 'application/json',
+                    'xi-api-key': apiKey
+                },
+                body: JSON.stringify({
+                    text: text,
+                    model_id: modelId,
+                    voice_settings: {
+                        stability: stability,
+                        similarity_boost: similarity_boost
+                    }
+            })
         );
+
+        if (!response.ok) {
+            const error = await response.text();
+            throw new Error(`ElevenLabs API错误 (${response.status}): ${error}`);
+        }
+
+        return await response.blob();
     }
 
-    return await res.json();
+    // 统一接口：获取模型列表（从ST复制）
+    async getModels(settings) {
+        return [
+            { id: 'eleven_v3', name: 'Eleven v3' },
+            { id: 'eleven_ttv_v3', name: 'Eleven ttv v3' },
+            { id: 'eleven_multilingual_v2', name: 'Multilingual v2' },
+            { id: 'eleven_flash_v2_5', name: 'Eleven Flash v2.5' },
+            { id: 'eleven_turbo_v2_5', name: 'Turbo v2.5 (推荐)' },
+            { id: 'eleven_multilingual_ttv_v2', name: 'Multilingual ttv v2' },
+            { id: 'eleven_monolingual_v1', name: 'English v1 (Old)' },
+            { id: 'eleven_multilingual_v1', name: 'Multilingual v1 (Old)' },
+            { id: 'eleven_turbo_v2', name: 'Turbo v2 (Old)' }
+        ];
+    }
+
+    // 统一接口：获取音色列表
+    async getVoices(settings) {
+        if (!settings.key) {
+            throw new Error('请先填写ElevenLabs API Key');
+        }
+        
+        const fetchFn = this.fetchImpl;
+        if (typeof fetchFn !== 'function') {
+            throw new Error('当前环境不支持 fetch');
+        }
+
+        const response = await fetchFn(`${this.apiEndpoint}/voices`, {
+            headers: {
+                'xi-api-key': settings.key,
+            },
+        });
+        
+        if (!response.ok) {
+            throw new Error(`获取音色列表失败: ${response.status} - ${await response.text()}`);
+        }
+        
+        const data = await response.json();
+        
+        // 转换为统一格式
+        return data.voices.map(voice => ({
+            id: voice.voice_id,
+            name: voice.name,
+            group: voice.category === 'premade' ? '官方预设' : 
+                   voice.category === 'cloned' ? '克隆音色' : 
+                   voice.category === 'professional' ? '专业音色' : '其他'
+        }));
+    }
+
+    // 不支持通过API上传音色
+    async uploadVoice(data, settings) {
+        throw new Error('ElevenLabs的音色克隆需要在官网进行');
+    }
+
+    // 不支持通过API删除音色
+    async deleteVoice(voiceId, settings) {
+        throw new Error('请在ElevenLabs官网管理音色');
+    }
 }

--- a/setting/voice/index.js
+++ b/setting/voice/index.js
@@ -1,11 +1,11 @@
 import {
-    DEFAULT_TTS_ENDPOINT,
     DEFAULT_TTS_MODEL,
     DEFAULT_TTS_VOICE,
     DEFAULT_TTS_SPEED,
+    DEFAULT_TTS_ENDPOINT,
+    DEFAULT_TTS_VENDOR,
+    TTS_VENDORS,
 } from '../tts/constants.js';
-import { SILICON_FLOW_TTS_API_DOC } from '../tts/apiDocs.js';
-
 const voiceState = {
     elements: {},
     dependencies: {
@@ -18,7 +18,46 @@ const voiceState = {
     isPlaying: false,
     currentAudio: null,
     currentBubble: null,
+    elevenLabsProviderPromise: null,
 };
+
+const VENDOR_MAP = TTS_VENDORS.reduce((map, vendor) => {
+    map[vendor.id] = vendor;
+    return map;
+}, {});
+
+const SILICON_VENDOR_ID = 'siliconflow';
+const ELEVEN_VENDOR_ID = 'elevenlabs';
+const ELEVEN_DEFAULT_MODEL = 'eleven_multilingual_v2';
+const ELEVEN_DEFAULT_VOICE = 'EXAVITQu4vr4xnSDxMaL';
+
+async function getElevenLabsProvider() {
+    if (!voiceState.elevenLabsProviderPromise) {
+        voiceState.elevenLabsProviderPromise = import(
+            '../tts/setting/tts/elevenlabs.js'
+        )
+            .then((module) => {
+                const Provider = module?.default;
+                if (typeof Provider !== 'function') {
+                    throw new Error('未找到 ElevenLabs 提供器');
+                }
+                return new Provider({ fetch: getDeps().fetchRef });
+            })
+            .catch((error) => {
+                voiceState.elevenLabsProviderPromise = null;
+                throw error;
+            });
+    }
+    return voiceState.elevenLabsProviderPromise;
+}
+
+function resolveEndpoint(vendorId) {
+    return VENDOR_MAP[vendorId]?.endpoint || DEFAULT_TTS_ENDPOINT;
+}
+
+function getVendorName(vendorId) {
+    return VENDOR_MAP[vendorId]?.name || VENDOR_MAP[SILICON_VENDOR_ID]?.name || '';
+}
 
 function getElements() {
     return voiceState.elements;
@@ -28,8 +67,12 @@ function getDeps() {
     return voiceState.dependencies;
 }
 
-function getDefaultEndpoint() {
-    return DEFAULT_TTS_ENDPOINT;
+function getSelectedVendor() {
+    return getElements().ttsVendorSelect?.value || DEFAULT_TTS_VENDOR;
+}
+
+function getDefaultEndpoint(vendorId = getSelectedVendor()) {
+    return resolveEndpoint(vendorId);
 }
 
 function getTTSSettings() {
@@ -43,25 +86,33 @@ function getTTSSettings() {
     if (!settings) {
         settings = {
             key: '',
-            endpoint: getDefaultEndpoint(),
             model: '',
             voice: '',
+            vendor: DEFAULT_TTS_VENDOR,
         };
     }
-    if (!settings.endpoint) settings.endpoint = getDefaultEndpoint();
+    if (!settings.vendor && settings.endpoint) {
+        const matched = TTS_VENDORS.find(
+            (vendor) => vendor.endpoint === settings.endpoint,
+        );
+        if (matched) settings.vendor = matched.id;
+    }
+    if (!settings.vendor) settings.vendor = DEFAULT_TTS_VENDOR;
+    settings.endpoint = getDefaultEndpoint(settings.vendor);
     return settings;
 }
 
 function applyTTSSettingsToUI(settings) {
     const {
+        ttsVendorSelect,
         ttsKeyInput,
-        ttsEndpointInput,
         ttsModelInput,
         ttsVoiceInput,
     } = getElements();
+    if (ttsVendorSelect) {
+        ttsVendorSelect.value = settings.vendor || DEFAULT_TTS_VENDOR;
+    }
     if (ttsKeyInput) ttsKeyInput.value = settings.key || '';
-    if (ttsEndpointInput)
-        ttsEndpointInput.value = settings.endpoint || getDefaultEndpoint();
     if (ttsModelInput && settings.model) {
         if (
             !ttsModelInput.options.length ||
@@ -88,17 +139,18 @@ function applyTTSSettingsToUI(settings) {
 
 function readTTSSettingsFromUI() {
     const {
+        ttsVendorSelect,
         ttsKeyInput,
-        ttsEndpointInput,
         ttsModelInput,
         ttsVoiceInput,
     } = getElements();
+    const vendor = ttsVendorSelect?.value || DEFAULT_TTS_VENDOR;
     return {
         key: (ttsKeyInput?.value || '').trim(),
-        endpoint:
-            (ttsEndpointInput?.value || '').trim() || getDefaultEndpoint(),
         model: (ttsModelInput?.value || '').trim(),
         voice: (ttsVoiceInput?.value || '').trim(),
+        vendor,
+        endpoint: getDefaultEndpoint(vendor),
     };
 }
 
@@ -121,7 +173,7 @@ function updateTTSStatus(text, isError = false) {
 }
 
 async function fetchSiliconFlowTTS(text, settings) {
-    const base = settings.endpoint || getDefaultEndpoint();
+    const base = getDefaultEndpoint(settings.vendor || SILICON_VENDOR_ID);
     const endpoint = base.endsWith('/audio/speech')
         ? base
         : `${base.replace(/\/$/, '')}/audio/speech`;
@@ -149,6 +201,158 @@ async function fetchSiliconFlowTTS(text, settings) {
         throw new Error(`HTTP ${res.status}: ${await res.text()}`);
     }
     return await res.blob();
+}
+
+async function fetchElevenLabsTTS(text, settings) {
+    const payload = {
+        key: settings.key,
+        model: settings.model || ELEVEN_DEFAULT_MODEL,
+        voice: settings.voice || ELEVEN_DEFAULT_VOICE,
+        stability: settings.stability,
+        similarity: settings.similarity,
+    };
+    if (!payload.key) throw new Error('请先填写ElevenLabs API Key');
+    const provider = await getElevenLabsProvider();
+    return await provider.synthesize(text, payload);
+}
+
+function updateVendorUI(vendor) {
+    const {
+        ttsKeyInput,
+        ttsUploadBtn,
+        ttsUploadFile,
+        ttsUploadFileBtn,
+        ttsVoiceDeleteBtn,
+        ttsVoiceInput,
+        ttsUploadName,
+        ttsUploadText,
+    } = getElements();
+    if (ttsKeyInput) {
+        ttsKeyInput.placeholder =
+            vendor === ELEVEN_VENDOR_ID
+                ? '填写ElevenLabs API Key'
+                : '填写硅基流动 API Key';
+    }
+    const disableUpload = vendor === ELEVEN_VENDOR_ID;
+    [
+        ttsUploadBtn,
+        ttsUploadFileBtn,
+        ttsUploadFile,
+        ttsVoiceDeleteBtn,
+        ttsUploadName,
+        ttsUploadText,
+    ]
+        .filter(Boolean)
+        .forEach((el) => {
+            el.disabled = disableUpload;
+        });
+    if (ttsVoiceInput && vendor !== ELEVEN_VENDOR_ID) {
+        ttsVoiceInput.disabled = false;
+    }
+}
+
+async function populateElevenLabsModels(settings) {
+    const { ttsModelInput } = getElements();
+    if (!ttsModelInput) return;
+    const provider = await getElevenLabsProvider();
+    const models = await provider.getModels(settings);
+    ttsModelInput.innerHTML = '';
+    models.forEach((model) => {
+        ttsModelInput.appendChild(new Option(model.name, model.id));
+    });
+    const fallback = models[0]?.id || '';
+    const value =
+        settings.model && ttsModelInput.querySelector(`option[value="${settings.model}"]`)
+            ? settings.model
+            : fallback;
+    if (value) ttsModelInput.value = value;
+}
+
+async function populateElevenLabsVoices(settings) {
+    const { ttsVoiceInput } = getElements();
+    if (!ttsVoiceInput) return;
+    const doc = getDeps().documentRef;
+    ttsVoiceInput.innerHTML = '';
+    if (!settings.key) {
+        ttsVoiceInput.appendChild(new Option('请先填写ElevenLabs API Key', ''));
+        ttsVoiceInput.disabled = true;
+        return;
+    }
+    ttsVoiceInput.disabled = false;
+    const provider = await getElevenLabsProvider();
+    const voices = await provider.getVoices(settings);
+    const groupMap = new Map();
+    voices.forEach((voice) => {
+        const group = voice.group || '其他';
+        if (!groupMap.has(group)) groupMap.set(group, []);
+        groupMap.get(group).push(voice);
+    });
+    if (doc && groupMap.size) {
+        groupMap.forEach((list, group) => {
+            const optGroup = doc.createElement('optgroup');
+            optGroup.label = group;
+            list.forEach((voice) => {
+                optGroup.appendChild(new Option(voice.name, voice.id));
+            });
+            ttsVoiceInput.appendChild(optGroup);
+        });
+    } else {
+        voices.forEach((voice) => {
+            ttsVoiceInput.appendChild(new Option(voice.name, voice.id));
+        });
+    }
+    if (!ttsVoiceInput.options.length) {
+        ttsVoiceInput.appendChild(new Option('未获取到音色', ''));
+        ttsVoiceInput.disabled = true;
+        return;
+    }
+    const match =
+        settings.voice &&
+        ttsVoiceInput.querySelector(`option[value="${settings.voice}"]`)
+            ? settings.voice
+            : ttsVoiceInput.querySelector('option[value]')?.value;
+    if (match) ttsVoiceInput.value = match;
+}
+
+async function loadElevenLabsOptions(settings, { updateStatus = true } = {}) {
+    try {
+        await populateElevenLabsModels(settings);
+        await populateElevenLabsVoices(settings);
+        if (updateStatus && settings.key) {
+            updateTTSStatus('已加载ElevenLabs模型与音色');
+        }
+    } catch (error) {
+        if (updateStatus) {
+            updateTTSStatus(`加载ElevenLabs数据失败: ${error.message || error}`, true);
+        }
+        throw error;
+    }
+}
+
+function setupVendorChangeHandler() {
+    const { ttsVendorSelect, ttsModelInput } = getElements();
+    if (!ttsVendorSelect) return;
+    ttsVendorSelect.addEventListener('change', async () => {
+        const vendor = getSelectedVendor();
+        updateVendorUI(vendor);
+        const settings = readTTSSettingsFromUI();
+        saveTTSSettings(settings);
+        if (vendor === ELEVEN_VENDOR_ID) {
+            try {
+                await loadElevenLabsOptions(settings, { updateStatus: false });
+                if (settings.key) {
+                    updateTTSStatus('已切换至ElevenLabs并加载音色');
+                } else {
+                    updateTTSStatus('请输入ElevenLabs API Key 以加载音色');
+                }
+            } catch (error) {
+                console.warn('加载ElevenLabs数据失败', error);
+            }
+        } else {
+            ttsModelInput?.dispatchEvent(new Event('change'));
+            updateTTSStatus('已切换至硅基流动');
+        }
+    });
 }
 
 function playNextAudio() {
@@ -208,10 +412,20 @@ function playImmediateBlob(blob) {
 
 async function synthesizeTTS(text, playOnReady = true) {
     const settings = readTTSSettingsFromUI();
-    if (!settings.key) throw new Error('请先填写硅基流动 API Key');
-    if (!settings.model) settings.model = DEFAULT_TTS_MODEL;
-    if (!settings.voice) settings.voice = DEFAULT_TTS_VOICE;
-    const blob = await fetchSiliconFlowTTS(text, settings);
+    const vendor = settings.vendor || DEFAULT_TTS_VENDOR;
+    if (vendor === ELEVEN_VENDOR_ID) {
+        if (!settings.model) settings.model = ELEVEN_DEFAULT_MODEL;
+        if (!settings.voice) settings.voice = ELEVEN_DEFAULT_VOICE;
+    } else {
+        if (!settings.key)
+            throw new Error(`请先填写${getVendorName(vendor)} API Key`);
+        if (!settings.model) settings.model = DEFAULT_TTS_MODEL;
+        if (!settings.voice) settings.voice = DEFAULT_TTS_VOICE;
+    }
+    const blob =
+        vendor === ELEVEN_VENDOR_ID
+            ? await fetchElevenLabsTTS(text, settings)
+            : await fetchSiliconFlowTTS(text, settings);
     if (playOnReady) {
         voiceState.queue.push(blob);
         if (!voiceState.isPlaying) playNextAudio();
@@ -245,6 +459,9 @@ function setupModelChangeHandler() {
     ttsModelInput.addEventListener('change', async () => {
         const doc = getDeps().documentRef;
         if (!doc) return;
+        if (getSelectedVendor() !== SILICON_VENDOR_ID) {
+            return;
+        }
         ttsVoiceInput.innerHTML = '';
         const cosyModel = 'FunAudioLLM/CosyVoice2-0.5B';
         const cosyPreset = [
@@ -346,6 +563,10 @@ function setupUploadHandlers() {
     if (ttsUploadBtn) {
         ttsUploadBtn.addEventListener('click', async () => {
             try {
+                if (getSelectedVendor() !== SILICON_VENDOR_ID) {
+                    updateTTSStatus('当前厂商不支持音色上传', true);
+                    return;
+                }
                 if (!ttsKeyInput?.value) {
                     throw new Error('请先填写硅基流动 API Key');
                 }
@@ -394,6 +615,10 @@ function setupDeleteVoiceHandler() {
     if (!ttsVoiceDeleteBtn || !ttsVoiceInput) return;
     ttsVoiceDeleteBtn.addEventListener('click', async () => {
         try {
+            if (getSelectedVendor() !== SILICON_VENDOR_ID) {
+                updateTTSStatus('当前厂商不支持删除操作', true);
+                return;
+            }
             const val = ttsVoiceInput.value || '';
             if (!val) {
                 updateTTSStatus('请先选择要删除的音色', true);
@@ -437,9 +662,19 @@ function setupDeleteVoiceHandler() {
 function setupRefreshHandler() {
     const { ttsRefreshVoicesBtn, ttsModelInput } = getElements();
     if (ttsRefreshVoicesBtn) {
-        ttsRefreshVoicesBtn.addEventListener('click', () => {
-            ttsModelInput?.dispatchEvent(new Event('change'));
-            updateTTSStatus('音色已刷新');
+        ttsRefreshVoicesBtn.addEventListener('click', async () => {
+            const vendor = getSelectedVendor();
+            if (vendor === ELEVEN_VENDOR_ID) {
+                const settings = readTTSSettingsFromUI();
+                try {
+                    await loadElevenLabsOptions(settings, { updateStatus: true });
+                } catch (error) {
+                    console.warn('刷新ElevenLabs音色失败', error);
+                }
+            } else {
+                ttsModelInput?.dispatchEvent(new Event('change'));
+                updateTTSStatus('音色已刷新');
+            }
         });
     }
 }
@@ -451,6 +686,17 @@ function setupCheckHandler() {
         const settings = readTTSSettingsFromUI();
         try {
             updateTTSStatus('连接中...');
+            if (settings.vendor === ELEVEN_VENDOR_ID) {
+                await loadElevenLabsOptions(settings, { updateStatus: false });
+                saveTTSSettings(readTTSSettingsFromUI());
+                if (settings.key) {
+                    updateTTSStatus('连接成功，已加载ElevenLabs音色');
+                } else {
+                    updateTTSStatus('请填写ElevenLabs API Key 以加载音色');
+                }
+                return;
+            }
+
             const models = [
                 'FunAudioLLM/CosyVoice2-0.5B',
                 'fnlp/MOSS-TTSD-v0.5',
@@ -587,17 +833,14 @@ function setupSaveAndTest() {
 export function initVoiceSettings(elements, dependencies = {}) {
     voiceState.elements = elements || {};
     voiceState.dependencies = { ...voiceState.dependencies, ...dependencies };
+    voiceState.elevenLabsProviderPromise = null;
 
-    const { ttsEndpointInput, ttsEndpointLabel, ttsModelInput } = getElements();
-    if (ttsEndpointInput && !ttsEndpointInput.value) {
-        ttsEndpointInput.value = getDefaultEndpoint();
-    }
-    if (ttsEndpointLabel) {
-        ttsEndpointLabel.title = SILICON_FLOW_TTS_API_DOC;
-    }
+    const { ttsModelInput } = getElements();
+    const initialSettings = getTTSSettings();
+    applyTTSSettingsToUI(initialSettings);
+    updateVendorUI(initialSettings.vendor || DEFAULT_TTS_VENDOR);
 
-    applyTTSSettingsToUI(getTTSSettings());
-
+    setupVendorChangeHandler();
     setupTabs();
     setupSaveAndTest();
     setupSpeedControls();
@@ -607,7 +850,21 @@ export function initVoiceSettings(elements, dependencies = {}) {
     setupRefreshHandler();
     setupCheckHandler();
 
-    ttsModelInput?.dispatchEvent(new Event('change'));
+    if ((initialSettings.vendor || DEFAULT_TTS_VENDOR) === ELEVEN_VENDOR_ID) {
+        loadElevenLabsOptions(initialSettings, { updateStatus: false })
+            .then(() => {
+                if (initialSettings.key) {
+                    updateTTSStatus('已加载ElevenLabs模型与音色');
+                } else {
+                    updateTTSStatus('请输入ElevenLabs API Key 以加载音色');
+                }
+            })
+            .catch((error) => {
+                console.warn('初始化ElevenLabs音色失败', error);
+            });
+    } else {
+        ttsModelInput?.dispatchEvent(new Event('change'));
+    }
 
     return {
         synthesizeTTS,


### PR DESCRIPTION
## Summary
- add a TTS vendor selector to the settings UI in place of the endpoint input
- map vendors to fixed endpoints and persist the selected provider with the rest of the TTS settings
- integrate ElevenLabs synthesis and voice/model loading alongside existing SiliconFlow features and guard unsupported operations
- lazily load the ElevenLabs provider so it uses the injected fetch implementation and matches the plugin's dynamic import pattern

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f0f26087188322a4500d961a08830a