### PR TITLE
Add chat bubble regex replacement

### DIFF
--- a/regex.js
+++ b/regex.js
@@ -27,6 +27,74 @@ const REGEX_RULES = [
         },
     },
     {
+        id: 'bhl-bubble-self',
+        pattern: /\[(.*?)\\(.*?)\\(.*?)\]/gm,
+        createNode({ documentRef, groups }) {
+            const [name = '', time = '', message = ''] = groups;
+            const doc = documentRef || defaultDocument;
+            if (!doc) return null;
+
+            const container = doc.createElement('div');
+            container.style.margin = '10px 0';
+            container.style.maxWidth = '75%';
+            container.style.display = 'flex';
+            container.style.flexDirection = 'column';
+            container.style.alignItems = 'flex-end';
+            container.style.marginLeft = 'auto';
+
+            const header = doc.createElement('div');
+            header.style.fontSize = '12px';
+            header.style.color = '#8a8a8a';
+            header.style.marginRight = '5px';
+            header.style.marginBottom = '5px';
+
+            const nameSpan = doc.createElement('span');
+            nameSpan.textContent = name.trim();
+
+            header.appendChild(nameSpan);
+
+            const bodyWrapper = doc.createElement('div');
+            bodyWrapper.style.display = 'flex';
+            bodyWrapper.style.alignItems = 'flex-end';
+            bodyWrapper.style.width = '100%';
+            bodyWrapper.style.justifyContent = 'flex-end';
+
+            const timeSpan = doc.createElement('span');
+            timeSpan.style.fontSize = '12px';
+            timeSpan.style.color = '#b2b2b2';
+            timeSpan.style.marginRight = '8px';
+            timeSpan.style.flexShrink = '0';
+            timeSpan.textContent = time.trim();
+
+            const bubble = doc.createElement('div');
+            bubble.style.backgroundColor = '#8DE041';
+            bubble.style.color = '#000000';
+            bubble.style.padding = '12px 16px';
+            bubble.style.borderRadius = '20px';
+            bubble.style.boxShadow = '0 1px 2px rgba(0, 0, 0, 0.08)';
+            bubble.style.position = 'relative';
+            bubble.style.maxWidth = '100%';
+
+            const paragraph = doc.createElement('p');
+            paragraph.style.margin = '0';
+            paragraph.style.whiteSpace = 'pre-wrap';
+            paragraph.style.wordWrap = 'break-word';
+            paragraph.style.fontSize = '12px';
+            paragraph.style.lineHeight = '1.5';
+            paragraph.textContent = message.trim();
+
+            bubble.appendChild(paragraph);
+
+            bodyWrapper.appendChild(timeSpan);
+            bodyWrapper.appendChild(bubble);
+
+            container.appendChild(header);
+            container.appendChild(bodyWrapper);
+
+            return container;
+        },
+    },
+    {
         id: 'bhl-bubble',
         pattern: /\[(.*?)\/(.*?)\/(.*?)\]/gm,
         createNode({ documentRef, groups }) {


### PR DESCRIPTION
## Summary
- add a regex rule that formats [$1/$2/$3] patterns as styled chat bubbles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fb26fd6e988322a7942c2fa7d6aad3