### PR TITLE
Add Eden regex transformation

### DIFF
--- a/regex.js
+++ b/regex.js
@@ -227,8 +227,7 @@ const REGEX_RULES = [
     },
     {
         id: 'eden-details',
-        pattern:
-            /<伊甸园>\s*<time>(.*?)<\/time>\s*<location>(.*?)<\/location>\s*<character>\s*<AAA>\s*阶段：(.*?)\s*第(.*?)天\s*<\/AAA>\s*<namestr>(.*?)<\/namestr>\s*<appearance>\s*种族\|(.*?)\s*年龄\|(.*?)\s*<\/appearance>\s*<SSS>\s*小穴\|(.*?)\s*子宫\|(.*?)\s*菊穴\|(.*?)\s*直肠\|(.*?)\s*乳房\|(.*?)\s*特质\|(.*?)\s*<\/SSS>\s*<reproduction>\s*精子\|(.*?)\s*卵子\|(.*?)\s*胎数\|(.*?)\s*父亲\|(.*?)\s*健康\|(.*?)\s*供养\|(.*?)\s*反应\|(.*?)\s*<\/reproduction>\s*<\/character>\s*<\/伊甸园>/gs,
+        pattern: /<伊甸园>\s*<time>(.*?)<\/time>\s*<location>(.*?)<\/location>\s*<character>\s*<AAA>\s*阶段：(.*?)\s*第(.*?)天\s*<\/AAA>\s*<namestr>(.*?)<\/namestr>\s*<appearance>\s*种族\|(.*?)\s*年龄\|(.*?)\s*<\/appearance>\s*<SSS>\s*小穴\|(.*?)\s*子宫\|(.*?)\s*菊穴\|(.*?)\s*直肠\|(.*?)\s*乳房\|(.*?)\s*特质\|(.*?)\s*<\/SSS>\s*<reproduction>\s*精子\|(.*?)\s*卵子\|(.*?)\s*胎数\|(.*?)\s*父亲\|(.*?)\s*健康\|(.*?)\s*供养\|(.*?)\s*反应\|(.*?)\s*<\/reproduction>\s*<\/character>\s*<\/伊甸园>/gs,
         createNode({ documentRef, groups }) {
             const doc = documentRef || defaultDocument;
             if (!doc) return null;
@@ -650,4 +649,5 @@ export function clearRegexState(element) {
 
 export function getRegexRules() {
     return REGEX_RULES.slice();
+
 }


### PR DESCRIPTION
## Summary
- add a regex rule to transform 伊甸园 markup into styled details content

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690abaea4b30832290afeda17c160c7d

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new regex rule to transform 伊甸园 blocks into a styled, collapsible details component with appearance, physiology, and reproduction sections.
> 
> - **Regex rules**:
>   - **New `eden-details` rule**: Parses `<伊甸园>` markup (time, location, stage/day, name, appearance, physiology, reproduction) and renders a styled `<details>` block with a title row and collapsible sections for `生理信息` and `生殖信息`.
>   - **Helper**: Adds `createEdenSectionSummary(doc, label)` to standardize section summaries used by the new rule.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8cd1157d8a15117b53bcb9c89514395370c2ec1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->