### PR TITLE
Group regex rules and enforce global flags

### DIFF
--- a/regex.js
+++ b/regex.js
@@ -1117,20 +1117,29 @@ let cachedRuleSettings = null;
 let cachedCustomRules = null;
 let cachedProfileStore = null;
 
+function normalizeFlags(flags = 'g') {
+    const raw = typeof flags === 'string' ? flags : '';
+    const uniq = [];
+    for (const ch of `${raw}g`) {
+        if (!uniq.includes(ch)) uniq.push(ch);
+    }
+    return uniq.join('');
+}
+
 function parsePatternInput(input, fallbackFlags = 'gm') {
     if (typeof input !== 'string') return null;
     const trimmed = input.trim();
     if (!trimmed) return null;
 
     let source = trimmed;
-    let flags = fallbackFlags;
+    let flags = normalizeFlags(fallbackFlags);
 
     if (trimmed.startsWith('/') && trimmed.lastIndexOf('/') > 0) {
         const lastSlash = trimmed.lastIndexOf('/');
         source = trimmed.slice(1, lastSlash);
         const flagPart = trimmed.slice(lastSlash + 1).trim();
         if (flagPart) {
-            flags = flagPart;
+            flags = normalizeFlags(flagPart);
         }
     }
 
@@ -1369,9 +1378,10 @@ function buildPattern(rule, config) {
             config?.flags || rule.flags || 'g',
         ) || {
             source: config?.pattern || rule.patternSource,
-            flags: config?.flags || rule.flags || 'g',
+            flags: normalizeFlags(config?.flags || rule.flags || 'g'),
         };
-    const { source, flags } = parsed;
+    const { source } = parsed;
+    const flags = normalizeFlags(parsed.flags);
     try {
         return new RegExp(source, flags);
     } catch (error) {
@@ -1704,7 +1714,9 @@ export function updateRegexRuleSetting(ruleId, updates = {}) {
         ...settings[ruleId],
         ...updates,
         ...(typeof nextPattern === 'string' ? { pattern: nextPattern } : {}),
-        ...(typeof nextFlags === 'string' ? { flags: nextFlags } : {}),
+        ...(typeof nextFlags === 'string'
+            ? { flags: normalizeFlags(nextFlags) }
+            : {}),
     };
     return setRegexRuleSettings({
         ...settings,

--- a/script.js
+++ b/script.js
@@ -736,7 +736,7 @@
             return;
         }
 
-        for (const rule of rules) {
+        const createRuleRow = (rule) => {
             const row = document.createElement('div');
             row.className = 'cip-regex-rule';
 
@@ -816,8 +816,59 @@
             row.appendChild(patternBtn);
             row.appendChild(replacementBtn);
             row.appendChild(resetBtn);
-            regexRuleList.appendChild(row);
-        }
+            return row;
+        };
+
+        const createGroup = (title, items, collapsed = false) => {
+            const group = document.createElement('div');
+            group.className = 'cip-regex-group';
+
+            const header = document.createElement('button');
+            header.type = 'button';
+            header.className = 'cip-regex-group-header';
+            const headerTitle = document.createElement('span');
+            headerTitle.className = 'cip-regex-group-title';
+            headerTitle.textContent = `${title}（${items.length}）`;
+            const caret = document.createElement('span');
+            caret.className = 'cip-regex-group-caret';
+            caret.textContent = '▾';
+
+            header.appendChild(headerTitle);
+            header.appendChild(caret);
+
+            const body = document.createElement('div');
+            body.className = 'cip-regex-group-body';
+            if (collapsed) {
+                body.classList.add('collapsed');
+                caret.classList.add('collapsed');
+            }
+
+            header.addEventListener('click', () => {
+                body.classList.toggle('collapsed');
+                caret.classList.toggle('collapsed');
+            });
+
+            if (!items.length) {
+                const empty = document.createElement('div');
+                empty.className = 'cip-regex-empty';
+                empty.textContent = title === '自定义' ? '暂无自定义正则' : '暂无默认正则';
+                body.appendChild(empty);
+            } else {
+                for (const item of items) {
+                    body.appendChild(createRuleRow(item));
+                }
+            }
+
+            group.appendChild(header);
+            group.appendChild(body);
+            regexRuleList.appendChild(group);
+        };
+
+        const defaultRules = rules.filter((item) => !item.isCustom);
+        const customRules = rules.filter((item) => item.isCustom);
+
+        createGroup('默认', defaultRules);
+        createGroup('自定义', customRules, customRules.length === 0);
     }
 
     updateRegexMasterUI();

--- a/style.css
+++ b/style.css
@@ -792,6 +792,50 @@ emoji-picker {
     gap: 10px;
 }
 
+.cip-regex-group {
+    border: 1px solid var(--cip-border-color, rgba(255, 255, 255, 0.2));
+    border-radius: 12px;
+    background: var(--cip-input-bg-color, rgba(255, 255, 255, 0.06));
+    overflow: hidden;
+}
+
+.cip-regex-group-header {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 12px;
+    background: rgba(255, 255, 255, 0.06);
+    border: none;
+    color: var(--cip-text-color);
+    cursor: pointer;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+}
+
+.cip-regex-group-title {
+    font-size: 13px;
+}
+
+.cip-regex-group-caret {
+    transition: transform var(--cip-transition-speed);
+}
+
+.cip-regex-group-caret.collapsed {
+    transform: rotate(-90deg);
+}
+
+.cip-regex-group-body {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 10px;
+}
+
+.cip-regex-group-body.collapsed {
+    display: none;
+}
+
 .cip-regex-rule {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- group built-in and custom regex rules into collapsible sections within the settings UI
- add styling for the new regex rule groups
- normalize regex flags to always include the global flag to avoid hangs when adding custom rules

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69244244a00483228b5b8f4033591cff)