### PR TITLE
feat: add file-backed settings datastore

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,28 @@ MIT License
 ## 问题反馈
 
 如果您遇到任何问题或有建议，请在 [Issues](https://github.com/yourusername/SillyTavern-QuickInput/issues) 页面提出。 
+
+## 服务端文件持久化（SillyTavern 目录）
+
+本扩展支持把设置写入 **SillyTavern 扩展目录**（`.../public/scripts/extensions/third-party/carrot/`）下的 `settings.json`（或你在同步面板填写的文件名）。
+
+### 需要挂载后端接口
+
+前端会请求以下接口之一（按顺序尝试）：
+
+- `GET/PUT /api/plugins/carrot/settings?file=<filename>`
+- `GET/PUT /api/extensions/carrot/settings?file=<filename>`
+
+仓库已提供 `server.js`（Express Router），你可以在 SillyTavern 后端里挂载：
+
+```js
+const { router: carrotSettingsRouter } = require('./public/scripts/extensions/third-party/carrot/server.js');
+app.use('/api/plugins/carrot/settings', carrotSettingsRouter);
+```
+
+挂载后行为：
+- 首次读取会自动创建 `settings.json`。
+- 前端新增/修改/删除会立即 `PUT` 回文件。
+- 导入外部 JSON 会覆盖当前目标文件。
+- 同步面板“保存”会同时下载文件，并把同样内容写回扩展目录文件。
+

--- a/script.js
+++ b/script.js
@@ -28,10 +28,14 @@
     try {
         const dataStoreModule = await import('./setting/dataStore.js');
         if (typeof dataStoreModule.createDataStore === 'function') {
+            const startupFileName =
+                localStorage.getItem('cip_sync_filename_v1') || 'settings.json';
             settingsDataStore = dataStoreModule.createDataStore({
                 localStorageRef: localStorage,
+                rootDirName: 'carrot',
+                fileName: startupFileName,
             });
-            await settingsDataStore.load_data();
+            await settingsDataStore.load_data(startupFileName);
             settingsStorage = settingsDataStore.createStorageAdapter();
         }
     } catch (error) {

--- a/script.js
+++ b/script.js
@@ -22,6 +22,21 @@
     let isDocked = false;
     let dockedLauncherButton = null;
     let dockPlaceholder = null;
+    let settingsDataStore = null;
+    let settingsStorage = localStorage;
+
+    try {
+        const dataStoreModule = await import('./setting/dataStore.js');
+        if (typeof dataStoreModule.createDataStore === 'function') {
+            settingsDataStore = dataStoreModule.createDataStore({
+                localStorageRef: localStorage,
+            });
+            await settingsDataStore.load_data();
+            settingsStorage = settingsDataStore.createStorageAdapter();
+        }
+    } catch (error) {
+        console.warn('胡萝卜插件：初始化数据存储模块失败，将回退 localStorage', error);
+    }
 
     try {
         const regexModule = await import('./regex.js');
@@ -1025,7 +1040,7 @@
             },
             {
                 documentRef: document,
-                localStorageRef: localStorage,
+                localStorageRef: settingsStorage,
             },
         );
 
@@ -1063,7 +1078,7 @@
             },
             {
                 documentRef: document,
-                localStorageRef: localStorage,
+                localStorageRef: settingsStorage,
                 alertRef: (message) => alert(message),
                 confirmRef: (message) => confirm(message),
                 unsplashAccessKey,
@@ -1097,7 +1112,7 @@
                 ttsPanes,
             },
             {
-                localStorageRef: localStorage,
+                localStorageRef: settingsStorage,
                 fetchRef: fetch,
                 documentRef: document,
                 windowRef: window,
@@ -1117,7 +1132,7 @@
                 alarmStatus,
             },
             {
-                localStorageRef: localStorage,
+                localStorageRef: settingsStorage,
                 alertRef: (message) => alert(message),
                 confirmRef: (message) => confirm(message),
                 windowRef: window,
@@ -1134,7 +1149,8 @@
             },
             {
                 documentRef: document,
-                localStorageRef: localStorage,
+                localStorageRef: settingsStorage,
+                dataStore: settingsDataStore,
                 alertRef: (message) => alert(message),
             },
         );
@@ -1744,7 +1760,7 @@
     }
     function saveStickerData() {
         try {
-            localStorage.setItem('cip_sticker_data', JSON.stringify(stickerData));
+            settingsStorage.setItem('cip_sticker_data', JSON.stringify(stickerData));
         } catch (error) {
             console.error('胡萝卜插件：写入表情包数据失败', error);
         }
@@ -1753,7 +1769,7 @@
     }
     function loadStickerData() {
         try {
-            const stored = localStorage.getItem('cip_sticker_data');
+            const stored = settingsStorage.getItem('cip_sticker_data');
             stickerData = stored ? JSON.parse(stored) : {};
         } catch (error) {
             console.error('胡萝卜插件：读取表情包数据失败', error);

--- a/script.js
+++ b/script.js
@@ -32,7 +32,6 @@
                 localStorage.getItem('cip_sync_filename_v1') || 'settings.json';
             settingsDataStore = dataStoreModule.createDataStore({
                 localStorageRef: localStorage,
-                rootDirName: 'carrot',
                 fileName: startupFileName,
             });
             await settingsDataStore.load_data(startupFileName);

--- a/server.js
+++ b/server.js
@@ -1,0 +1,104 @@
+/**
+ * Carrot extension backend API for SillyTavern.
+ *
+ * 用法（在 SillyTavern 后端中挂载该 router）：
+ *   app.use('/api/plugins/carrot/settings', router)
+ *
+ * 接口：
+ *   GET /api/plugins/carrot/settings?file=settings.json
+ *   PUT /api/plugins/carrot/settings?file=settings.json
+ */
+
+const express = require('express');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+
+const router = express.Router();
+
+const DATA_VERSION = 1;
+const DEFAULT_FILE_NAME = 'settings.json';
+
+function buildDefaultState() {
+    return {
+        version: DATA_VERSION,
+        updatedAt: new Date().toISOString(),
+        records: {},
+    };
+}
+
+function sanitizeFileName(input) {
+    const raw = String(input || DEFAULT_FILE_NAME).trim() || DEFAULT_FILE_NAME;
+    const base = path.basename(raw);
+    return base.endsWith('.json') ? base : `${base}.json`;
+}
+
+function resolveCarrotDir() {
+    // 约定：此 server.js 位于 carrot 扩展根目录
+    return __dirname;
+}
+
+async function ensureFile(filePath) {
+    try {
+        await fs.access(filePath);
+    } catch {
+        await fs.writeFile(filePath, JSON.stringify(buildDefaultState(), null, 2), 'utf8');
+    }
+}
+
+router.get('/', async (req, res) => {
+    try {
+        const fileName = sanitizeFileName(req.query.file);
+        const carrotDir = resolveCarrotDir();
+        const filePath = path.join(carrotDir, fileName);
+
+        await ensureFile(filePath);
+        const raw = await fs.readFile(filePath, 'utf8');
+        if (!raw.trim()) {
+            const fallback = buildDefaultState();
+            await fs.writeFile(filePath, JSON.stringify(fallback, null, 2), 'utf8');
+            return res.json(fallback);
+        }
+
+        try {
+            const parsed = JSON.parse(raw);
+            return res.json(parsed);
+        } catch {
+            const fallback = buildDefaultState();
+            await fs.writeFile(filePath, JSON.stringify(fallback, null, 2), 'utf8');
+            return res.json(fallback);
+        }
+    } catch (error) {
+        console.error('[carrot] read settings failed', error);
+        return res.status(500).json({ error: String(error?.message || error) });
+    }
+});
+
+router.put('/', express.json({ limit: '2mb' }), async (req, res) => {
+    try {
+        const fileName = sanitizeFileName(req.query.file);
+        const carrotDir = resolveCarrotDir();
+        const filePath = path.join(carrotDir, fileName);
+
+        const payload = req.body;
+        if (!payload || typeof payload !== 'object') {
+            return res.status(400).json({ error: 'Invalid payload' });
+        }
+
+        const normalized = {
+            version: Number(payload.version) || DATA_VERSION,
+            updatedAt: payload.updatedAt || new Date().toISOString(),
+            records:
+                payload.records && typeof payload.records === 'object' && !Array.isArray(payload.records)
+                    ? payload.records
+                    : {},
+        };
+
+        await fs.writeFile(filePath, JSON.stringify(normalized, null, 2), 'utf8');
+        return res.json({ ok: true, file: fileName });
+    } catch (error) {
+        console.error('[carrot] write settings failed', error);
+        return res.status(500).json({ error: String(error?.message || error) });
+    }
+});
+
+module.exports = { router };

--- a/setting/dataStore.js
+++ b/setting/dataStore.js
@@ -1,4 +1,3 @@
-const DEFAULT_DIR_NAME = 'carrot';
 const DEFAULT_FILE_NAME = 'settings.json';
 const DATA_VERSION = 1;
 
@@ -19,6 +18,11 @@ const MANAGED_KEYS = Object.freeze([
     'cip_regex_profiles_v1',
     'cip_alarm_data_v1',
 ]);
+
+const API_BASE_CANDIDATES = [
+    '/api/plugins/carrot/settings',
+    '/api/extensions/carrot/settings',
+];
 
 function buildDefaultState() {
     return {
@@ -45,37 +49,14 @@ function normalizeFileName(fileName) {
 
 export function createDataStore({
     localStorageRef = typeof localStorage !== 'undefined' ? localStorage : null,
-    fileName = DEFAULT_FILE_NAME,
-    rootDirName = DEFAULT_DIR_NAME,
+    fetchRef = typeof fetch !== 'undefined' ? fetch : null,
     consoleRef = console,
+    fileName = DEFAULT_FILE_NAME,
 } = {}) {
     let state = buildDefaultState();
     let saveQueue = Promise.resolve();
-    let dirHandle = null;
     let currentFileName = normalizeFileName(fileName);
-
-    async function getDirHandle() {
-        if (!navigator?.storage?.getDirectory) return null;
-        if (dirHandle) return dirHandle;
-        const root = await navigator.storage.getDirectory();
-        dirHandle = await root.getDirectoryHandle(rootDirName, { create: true });
-        return dirHandle;
-    }
-
-    async function getFileHandle(targetFileName = currentFileName) {
-        const dir = await getDirHandle();
-        if (!dir) return null;
-        return dir.getFileHandle(normalizeFileName(targetFileName), { create: true });
-    }
-
-    async function writeStateToFile(targetFileName = currentFileName) {
-        const handle = await getFileHandle(targetFileName);
-        if (!handle) return false;
-        const writable = await handle.createWritable();
-        await writable.write(JSON.stringify(state, null, 2));
-        await writable.close();
-        return true;
-    }
+    let workingApiBase = null;
 
     function syncStateToLocalStorage() {
         if (!localStorageRef) return;
@@ -102,67 +83,115 @@ export function createDataStore({
         state.updatedAt = new Date().toISOString();
     }
 
-    async function queueSave(targetFileName = currentFileName) {
+    async function requestApi(base, method, payload = null) {
+        if (!fetchRef) return null;
+        const url = `${base}?file=${encodeURIComponent(currentFileName)}`;
+        const options = { method, headers: {} };
+        if (payload !== null) {
+            options.headers['Content-Type'] = 'application/json';
+            options.body = JSON.stringify(payload);
+        }
+        const response = await fetchRef(url, options);
+        return response;
+    }
+
+    async function tryApi(method, payload = null) {
+        if (!fetchRef) return { ok: false, reason: 'fetch unavailable' };
+        const candidates = workingApiBase
+            ? [workingApiBase, ...API_BASE_CANDIDATES.filter((x) => x !== workingApiBase)]
+            : [...API_BASE_CANDIDATES];
+
+        for (const base of candidates) {
+            try {
+                const response = await requestApi(base, method, payload);
+                if (!response) continue;
+                if (response.ok) {
+                    workingApiBase = base;
+                    return { ok: true, response, base };
+                }
+                if (response.status === 404 || response.status === 405) {
+                    continue;
+                }
+                const text = await response.text().catch(() => '');
+                return {
+                    ok: false,
+                    reason: `HTTP ${response.status} ${text}`,
+                };
+            } catch (error) {
+                // 尝试下一个候选端点
+            }
+        }
+
+        return { ok: false, reason: 'no SillyTavern endpoint available' };
+    }
+
+    async function saveToServerFile() {
+        const result = await tryApi('PUT', state);
+        if (!result.ok) {
+            throw new Error(result.reason || 'server save failed');
+        }
+    }
+
+    async function queueSave() {
         state.updatedAt = new Date().toISOString();
         saveQueue = saveQueue
             .catch(() => {})
             .then(async () => {
                 syncStateToLocalStorage();
-                try {
-                    await writeStateToFile(targetFileName);
-                } catch (error) {
-                    consoleRef.warn('Carrot 数据文件写入失败，已保留在 localStorage。', error);
-                }
+                await saveToServerFile();
             });
         await saveQueue;
     }
 
     async function load_data(targetFileName = currentFileName) {
         currentFileName = normalizeFileName(targetFileName);
-        const handle = await getFileHandle(currentFileName);
-        if (!handle) {
-            hydrateFromLocalStorage();
-            return state;
-        }
+        const result = await tryApi('GET');
 
-        const file = await handle.getFile();
-        const text = await file.text();
-
-        if (!text.trim()) {
+        if (!result.ok) {
             hydrateFromLocalStorage();
-            await queueSave(currentFileName);
+            try {
+                await queueSave();
+            } catch (error) {
+                consoleRef.warn('Carrot 无法访问酒馆文件接口，已退回 localStorage。', error);
+            }
             return state;
         }
 
         try {
-            const parsed = JSON.parse(text);
-            if (!isValidState(parsed)) throw new Error('invalid schema');
+            const payload = await result.response.json();
+            if (!isValidState(payload)) {
+                throw new Error('invalid schema');
+            }
             state = {
-                version: Number(parsed.version) || DATA_VERSION,
-                updatedAt: parsed.updatedAt || new Date().toISOString(),
-                records: { ...parsed.records },
+                version: Number(payload.version) || DATA_VERSION,
+                updatedAt: payload.updatedAt || new Date().toISOString(),
+                records: { ...payload.records },
             };
             syncStateToLocalStorage();
         } catch (error) {
-            consoleRef.warn('Carrot 数据文件损坏，已执行兜底恢复。', error);
+            consoleRef.warn('Carrot 服务端 settings.json 损坏，使用本地兜底重建。', error);
             state = buildDefaultState();
             hydrateFromLocalStorage();
-            await queueSave(currentFileName);
+            await queueSave();
         }
 
         return state;
     }
 
     async function save_data() {
-        await queueSave(currentFileName);
+        try {
+            await queueSave();
+        } catch (error) {
+            consoleRef.warn('Carrot 写入酒馆文件失败，仅保留 localStorage。', error);
+            syncStateToLocalStorage();
+        }
         return state;
     }
 
     async function setFileName(fileNameToSet, { reload = true } = {}) {
-        const nextFileName = normalizeFileName(fileNameToSet);
-        currentFileName = nextFileName;
+        currentFileName = normalizeFileName(fileNameToSet);
         if (reload) {
-            await load_data(nextFileName);
+            await load_data(currentFileName);
         }
         return currentFileName;
     }
@@ -176,19 +205,19 @@ export function createDataStore({
             throw new Error(`记录已存在: ${key}`);
         }
         state.records[key] = value;
-        await queueSave();
+        await save_data();
         return value;
     }
 
     async function update_item(key, value) {
         state.records[key] = value;
-        await queueSave();
+        await save_data();
         return value;
     }
 
     async function delete_item(key) {
         delete state.records[key];
-        await queueSave();
+        await save_data();
     }
 
     function get_item(key) {
@@ -208,9 +237,7 @@ export function createDataStore({
     function createStorageAdapter() {
         return {
             getItem(key) {
-                if (isManagedKey(key)) {
-                    return get_item(key);
-                }
+                if (isManagedKey(key)) return get_item(key);
                 return localStorageRef?.getItem(key) ?? null;
             },
             setItem(key, value) {
@@ -249,7 +276,7 @@ export function createDataStore({
                 updatedAt: payload.updatedAt || new Date().toISOString(),
                 records: { ...payload.records },
             };
-            await queueSave();
+            await save_data();
             return;
         }
 
@@ -261,7 +288,7 @@ export function createDataStore({
             }
         });
         state.records = legacy;
-        await queueSave();
+        await save_data();
     }
 
     return {

--- a/setting/dataStore.js
+++ b/setting/dataStore.js
@@ -1,4 +1,5 @@
-const DATA_FILE_NAME = 'carrot-input-panel-settings.json';
+const DEFAULT_DIR_NAME = 'carrot';
+const DEFAULT_FILE_NAME = 'settings.json';
 const DATA_VERSION = 1;
 
 const MANAGED_KEYS = Object.freeze([
@@ -36,25 +37,39 @@ function isValidState(candidate) {
     );
 }
 
+function normalizeFileName(fileName) {
+    const raw = `${fileName || ''}`.trim();
+    if (!raw) return DEFAULT_FILE_NAME;
+    return raw.endsWith('.json') ? raw : `${raw}.json`;
+}
+
 export function createDataStore({
     localStorageRef = typeof localStorage !== 'undefined' ? localStorage : null,
-    fileName = DATA_FILE_NAME,
+    fileName = DEFAULT_FILE_NAME,
+    rootDirName = DEFAULT_DIR_NAME,
     consoleRef = console,
 } = {}) {
     let state = buildDefaultState();
     let saveQueue = Promise.resolve();
-    let fileHandle = null;
+    let dirHandle = null;
+    let currentFileName = normalizeFileName(fileName);
 
-    async function getFileHandle() {
+    async function getDirHandle() {
         if (!navigator?.storage?.getDirectory) return null;
-        if (fileHandle) return fileHandle;
+        if (dirHandle) return dirHandle;
         const root = await navigator.storage.getDirectory();
-        fileHandle = await root.getFileHandle(fileName, { create: true });
-        return fileHandle;
+        dirHandle = await root.getDirectoryHandle(rootDirName, { create: true });
+        return dirHandle;
     }
 
-    async function writeStateToFile() {
-        const handle = await getFileHandle();
+    async function getFileHandle(targetFileName = currentFileName) {
+        const dir = await getDirHandle();
+        if (!dir) return null;
+        return dir.getFileHandle(normalizeFileName(targetFileName), { create: true });
+    }
+
+    async function writeStateToFile(targetFileName = currentFileName) {
+        const handle = await getFileHandle(targetFileName);
         if (!handle) return false;
         const writable = await handle.createWritable();
         await writable.write(JSON.stringify(state, null, 2));
@@ -74,14 +89,27 @@ export function createDataStore({
         });
     }
 
-    async function queueSave() {
+    function hydrateFromLocalStorage() {
+        if (!localStorageRef) return;
+        const next = {};
+        MANAGED_KEYS.forEach((key) => {
+            const value = localStorageRef.getItem(key);
+            if (typeof value === 'string') {
+                next[key] = value;
+            }
+        });
+        state.records = next;
+        state.updatedAt = new Date().toISOString();
+    }
+
+    async function queueSave(targetFileName = currentFileName) {
         state.updatedAt = new Date().toISOString();
         saveQueue = saveQueue
             .catch(() => {})
             .then(async () => {
                 syncStateToLocalStorage();
                 try {
-                    await writeStateToFile();
+                    await writeStateToFile(targetFileName);
                 } catch (error) {
                     consoleRef.warn('Carrot 数据文件写入失败，已保留在 localStorage。', error);
                 }
@@ -89,18 +117,20 @@ export function createDataStore({
         await saveQueue;
     }
 
-    async function load_data() {
-        const handle = await getFileHandle();
+    async function load_data(targetFileName = currentFileName) {
+        currentFileName = normalizeFileName(targetFileName);
+        const handle = await getFileHandle(currentFileName);
         if (!handle) {
             hydrateFromLocalStorage();
             return state;
         }
+
         const file = await handle.getFile();
         const text = await file.text();
 
         if (!text.trim()) {
             hydrateFromLocalStorage();
-            await queueSave();
+            await queueSave(currentFileName);
             return state;
         }
 
@@ -117,28 +147,28 @@ export function createDataStore({
             consoleRef.warn('Carrot 数据文件损坏，已执行兜底恢复。', error);
             state = buildDefaultState();
             hydrateFromLocalStorage();
-            await queueSave();
+            await queueSave(currentFileName);
         }
 
         return state;
     }
 
-    function hydrateFromLocalStorage() {
-        if (!localStorageRef) return;
-        const next = {};
-        MANAGED_KEYS.forEach((key) => {
-            const value = localStorageRef.getItem(key);
-            if (typeof value === 'string') {
-                next[key] = value;
-            }
-        });
-        state.records = next;
-        state.updatedAt = new Date().toISOString();
+    async function save_data() {
+        await queueSave(currentFileName);
+        return state;
     }
 
-    async function save_data() {
-        await queueSave();
-        return state;
+    async function setFileName(fileNameToSet, { reload = true } = {}) {
+        const nextFileName = normalizeFileName(fileNameToSet);
+        currentFileName = nextFileName;
+        if (reload) {
+            await load_data(nextFileName);
+        }
+        return currentFileName;
+    }
+
+    function getFileName() {
+        return currentFileName;
     }
 
     async function create_item(key, value) {
@@ -223,7 +253,6 @@ export function createDataStore({
             return;
         }
 
-        // 兼容旧版本导出格式（扁平 key-value）
         const legacy = {};
         MANAGED_KEYS.forEach((key) => {
             const value = payload[key];
@@ -238,6 +267,8 @@ export function createDataStore({
     return {
         load_data,
         save_data,
+        setFileName,
+        getFileName,
         create_item,
         update_item,
         delete_item,

--- a/setting/dataStore.js
+++ b/setting/dataStore.js
@@ -1,0 +1,251 @@
+const DATA_FILE_NAME = 'carrot-input-panel-settings.json';
+const DATA_VERSION = 1;
+
+const MANAGED_KEYS = Object.freeze([
+    'cip_sticker_data',
+    'cip_theme_data_v1',
+    'cip_last_active_theme_v1',
+    'cip_avatar_profiles_v1',
+    'cip_last_avatar_profile_v1',
+    'cip_frame_profiles_v1',
+    'cip_last_frame_profile_v1',
+    'cip_custom_command_v1',
+    'cip_sync_filename_v1',
+    'cip_tts_settings_v1',
+    'cip_regex_enabled_v1',
+    'cip_regex_rule_settings_v1',
+    'cip_regex_custom_rules_v1',
+    'cip_regex_profiles_v1',
+    'cip_alarm_data_v1',
+]);
+
+function buildDefaultState() {
+    return {
+        version: DATA_VERSION,
+        updatedAt: new Date().toISOString(),
+        records: {},
+    };
+}
+
+function isValidState(candidate) {
+    return (
+        !!candidate &&
+        typeof candidate === 'object' &&
+        typeof candidate.records === 'object' &&
+        !Array.isArray(candidate.records)
+    );
+}
+
+export function createDataStore({
+    localStorageRef = typeof localStorage !== 'undefined' ? localStorage : null,
+    fileName = DATA_FILE_NAME,
+    consoleRef = console,
+} = {}) {
+    let state = buildDefaultState();
+    let saveQueue = Promise.resolve();
+    let fileHandle = null;
+
+    async function getFileHandle() {
+        if (!navigator?.storage?.getDirectory) return null;
+        if (fileHandle) return fileHandle;
+        const root = await navigator.storage.getDirectory();
+        fileHandle = await root.getFileHandle(fileName, { create: true });
+        return fileHandle;
+    }
+
+    async function writeStateToFile() {
+        const handle = await getFileHandle();
+        if (!handle) return false;
+        const writable = await handle.createWritable();
+        await writable.write(JSON.stringify(state, null, 2));
+        await writable.close();
+        return true;
+    }
+
+    function syncStateToLocalStorage() {
+        if (!localStorageRef) return;
+        MANAGED_KEYS.forEach((key) => {
+            const value = state.records[key];
+            if (typeof value === 'string') {
+                localStorageRef.setItem(key, value);
+            } else {
+                localStorageRef.removeItem(key);
+            }
+        });
+    }
+
+    async function queueSave() {
+        state.updatedAt = new Date().toISOString();
+        saveQueue = saveQueue
+            .catch(() => {})
+            .then(async () => {
+                syncStateToLocalStorage();
+                try {
+                    await writeStateToFile();
+                } catch (error) {
+                    consoleRef.warn('Carrot 数据文件写入失败，已保留在 localStorage。', error);
+                }
+            });
+        await saveQueue;
+    }
+
+    async function load_data() {
+        const handle = await getFileHandle();
+        if (!handle) {
+            hydrateFromLocalStorage();
+            return state;
+        }
+        const file = await handle.getFile();
+        const text = await file.text();
+
+        if (!text.trim()) {
+            hydrateFromLocalStorage();
+            await queueSave();
+            return state;
+        }
+
+        try {
+            const parsed = JSON.parse(text);
+            if (!isValidState(parsed)) throw new Error('invalid schema');
+            state = {
+                version: Number(parsed.version) || DATA_VERSION,
+                updatedAt: parsed.updatedAt || new Date().toISOString(),
+                records: { ...parsed.records },
+            };
+            syncStateToLocalStorage();
+        } catch (error) {
+            consoleRef.warn('Carrot 数据文件损坏，已执行兜底恢复。', error);
+            state = buildDefaultState();
+            hydrateFromLocalStorage();
+            await queueSave();
+        }
+
+        return state;
+    }
+
+    function hydrateFromLocalStorage() {
+        if (!localStorageRef) return;
+        const next = {};
+        MANAGED_KEYS.forEach((key) => {
+            const value = localStorageRef.getItem(key);
+            if (typeof value === 'string') {
+                next[key] = value;
+            }
+        });
+        state.records = next;
+        state.updatedAt = new Date().toISOString();
+    }
+
+    async function save_data() {
+        await queueSave();
+        return state;
+    }
+
+    async function create_item(key, value) {
+        if (Object.prototype.hasOwnProperty.call(state.records, key)) {
+            throw new Error(`记录已存在: ${key}`);
+        }
+        state.records[key] = value;
+        await queueSave();
+        return value;
+    }
+
+    async function update_item(key, value) {
+        state.records[key] = value;
+        await queueSave();
+        return value;
+    }
+
+    async function delete_item(key) {
+        delete state.records[key];
+        await queueSave();
+    }
+
+    function get_item(key) {
+        return Object.prototype.hasOwnProperty.call(state.records, key)
+            ? state.records[key]
+            : null;
+    }
+
+    function list_items() {
+        return { ...state.records };
+    }
+
+    function isManagedKey(key) {
+        return MANAGED_KEYS.includes(key);
+    }
+
+    function createStorageAdapter() {
+        return {
+            getItem(key) {
+                if (isManagedKey(key)) {
+                    return get_item(key);
+                }
+                return localStorageRef?.getItem(key) ?? null;
+            },
+            setItem(key, value) {
+                if (!isManagedKey(key)) {
+                    localStorageRef?.setItem(key, value);
+                    return;
+                }
+                void update_item(key, value);
+            },
+            removeItem(key) {
+                if (!isManagedKey(key)) {
+                    localStorageRef?.removeItem(key);
+                    return;
+                }
+                void delete_item(key);
+            },
+        };
+    }
+
+    function exportSnapshot() {
+        return {
+            version: state.version,
+            updatedAt: state.updatedAt,
+            records: { ...state.records },
+        };
+    }
+
+    async function importSnapshot(payload) {
+        if (!payload || typeof payload !== 'object') {
+            throw new Error('无效数据');
+        }
+
+        if (payload.records && isValidState(payload)) {
+            state = {
+                version: Number(payload.version) || DATA_VERSION,
+                updatedAt: payload.updatedAt || new Date().toISOString(),
+                records: { ...payload.records },
+            };
+            await queueSave();
+            return;
+        }
+
+        // 兼容旧版本导出格式（扁平 key-value）
+        const legacy = {};
+        MANAGED_KEYS.forEach((key) => {
+            const value = payload[key];
+            if (typeof value === 'string') {
+                legacy[key] = value;
+            }
+        });
+        state.records = legacy;
+        await queueSave();
+    }
+
+    return {
+        load_data,
+        save_data,
+        create_item,
+        update_item,
+        delete_item,
+        get_item,
+        list_items,
+        createStorageAdapter,
+        exportSnapshot,
+        importSnapshot,
+        managedKeys: MANAGED_KEYS,
+    };
+}

--- a/setting/sync.js
+++ b/setting/sync.js
@@ -94,31 +94,33 @@ export function initSyncSettings(
                 let settingsApplied = false;
 
                 if (dataStore?.importSnapshot) {
-                    const importResult = dataStore.importSnapshot(importedSettings);
-                    if (importResult && typeof importResult.then === 'function') {
-                        importResult
-                            .then(() => {
-                                alertRef('设置已成功导入！页面将自动刷新以应用所有更改。');
-                                setTimeout(() => getWindow()?.location.reload(), 500);
-                            })
-                            .catch((error) => {
-                                console.error('导入设置时发生错误:', error);
-                                alertRef('导入失败，文件格式可能不正确。请查看控制台获取更多信息。');
-                            })
-                            .finally(() => {
-                                event.target.value = '';
-                            });
-                        return;
-                    }
+                    const configuredName = (syncPathInput?.value || '').trim();
+                    const activeName = configuredName || 'settings.json';
+                    const importResult = dataStore
+                        .setFileName(activeName, { reload: false })
+                        .then(() => dataStore.importSnapshot(importedSettings));
+
+                    importResult
+                        .then(() => {
+                            alertRef('设置已成功导入！页面将自动刷新以应用所有更改。');
+                            setTimeout(() => getWindow()?.location.reload(), 500);
+                        })
+                        .catch((error) => {
+                            console.error('导入设置时发生错误:', error);
+                            alertRef('导入失败，文件格式可能不正确。请查看控制台获取更多信息。');
+                        })
+                        .finally(() => {
+                            event.target.value = '';
+                        });
+                    return;
+                }
+
+                for (const key in importedSettings) {
+                    if (!Object.prototype.hasOwnProperty.call(importedSettings, key))
+                        continue;
+                    if (key === 'cip_button_position_v4') continue;
+                    localStorageRef.setItem(key, importedSettings[key]);
                     settingsApplied = true;
-                } else {
-                    for (const key in importedSettings) {
-                        if (!Object.prototype.hasOwnProperty.call(importedSettings, key))
-                            continue;
-                        if (key === 'cip_button_position_v4') continue;
-                        localStorageRef.setItem(key, importedSettings[key]);
-                        settingsApplied = true;
-                    }
                 }
 
                 if (settingsApplied) {
@@ -152,6 +154,16 @@ export function initSyncSettings(
             return;
         }
         localStorageRef.setItem('cip_sync_filename_v1', filename);
+
+        if (dataStore?.setFileName && dataStore?.save_data) {
+            void dataStore
+                .setFileName(filename, { reload: false })
+                .then(() => dataStore.save_data())
+                .catch((error) => {
+                    console.error('同步写入Carrot本地文件失败:', error);
+                });
+        }
+
         exportSettings(filename);
     }
 
@@ -163,7 +175,7 @@ export function initSyncSettings(
     savePathBtn?.addEventListener('click', saveToPath);
     loadPathBtn?.addEventListener('click', loadFromPath);
 
-    const savedFilename = localStorageRef.getItem('cip_sync_filename_v1');
+    const savedFilename = localStorageRef.getItem('cip_sync_filename_v1') || 'settings.json';
     if (savedFilename && syncPathInput) {
         syncPathInput.value = savedFilename;
     }

--- a/setting/sync.js
+++ b/setting/sync.js
@@ -8,12 +8,13 @@ export function initSyncSettings(
     {
         documentRef = document,
         localStorageRef = localStorage,
+        dataStore = null,
         alertRef = (message) => alert(message),
     } = {},
 ) {
     function exportSettings(customFilename = '') {
         try {
-            const settingsToExport = {};
+            let settingsToExport = null;
             const keysToExport = [
                 'cip_sticker_data',
                 'cip_theme_data_v1',
@@ -30,16 +31,28 @@ export function initSyncSettings(
                 'cip_regex_custom_rules_v1',
                 'cip_regex_profiles_v1',
             ];
-            keysToExport.forEach((key) => {
-                const value = localStorageRef.getItem(key);
-                if (value !== null) {
-                    settingsToExport[key] = value;
-                }
-            });
-            if (Object.keys(settingsToExport).length === 0) {
+
+            if (dataStore?.exportSnapshot) {
+                settingsToExport = dataStore.exportSnapshot();
+            } else {
+                settingsToExport = {};
+                keysToExport.forEach((key) => {
+                    const value = localStorageRef.getItem(key);
+                    if (value !== null) {
+                        settingsToExport[key] = value;
+                    }
+                });
+            }
+
+            const hasRecords = settingsToExport.records
+                ? Object.keys(settingsToExport.records).length > 0
+                : Object.keys(settingsToExport).length > 0;
+
+            if (!hasRecords) {
                 alertRef('没有可导出的设置。');
                 return;
             }
+
             const jsonString = JSON.stringify(settingsToExport, null, 2);
             const blob = new Blob([jsonString], { type: 'application/json' });
             const url = URL.createObjectURL(blob);
@@ -79,13 +92,35 @@ export function initSyncSettings(
             try {
                 const importedSettings = JSON.parse(e.target.result);
                 let settingsApplied = false;
-                for (const key in importedSettings) {
-                    if (!Object.prototype.hasOwnProperty.call(importedSettings, key))
-                        continue;
-                    if (key === 'cip_button_position_v4') continue;
-                    localStorageRef.setItem(key, importedSettings[key]);
+
+                if (dataStore?.importSnapshot) {
+                    const importResult = dataStore.importSnapshot(importedSettings);
+                    if (importResult && typeof importResult.then === 'function') {
+                        importResult
+                            .then(() => {
+                                alertRef('设置已成功导入！页面将自动刷新以应用所有更改。');
+                                setTimeout(() => getWindow()?.location.reload(), 500);
+                            })
+                            .catch((error) => {
+                                console.error('导入设置时发生错误:', error);
+                                alertRef('导入失败，文件格式可能不正确。请查看控制台获取更多信息。');
+                            })
+                            .finally(() => {
+                                event.target.value = '';
+                            });
+                        return;
+                    }
                     settingsApplied = true;
+                } else {
+                    for (const key in importedSettings) {
+                        if (!Object.prototype.hasOwnProperty.call(importedSettings, key))
+                            continue;
+                        if (key === 'cip_button_position_v4') continue;
+                        localStorageRef.setItem(key, importedSettings[key]);
+                        settingsApplied = true;
+                    }
                 }
+
                 if (settingsApplied) {
                     alertRef('设置已成功导入！页面将自动刷新以应用所有更改。');
                     setTimeout(() => getWindow()?.location.reload(), 500);

--- a/setting/voice/index.js
+++ b/setting/voice/index.js
@@ -122,9 +122,10 @@ function updateTTSStatus(text, isError = false) {
 
 async function fetchSiliconFlowTTS(text, settings) {
     const base = settings.endpoint || getDefaultEndpoint();
-    const endpoint = base.endsWith('/audio/speech')
-        ? base
-        : `${base.replace(/\/$/, '')}/audio/speech`;
+    const normalizedBase = base.endsWith('/') ? base.slice(0, -1) : base;
+    const endpoint = normalizedBase.endsWith('/audio/speech')
+        ? normalizedBase
+        : `${normalizedBase}/audio/speech`;
     if (!settings.key) throw new Error('未配置硅基流动API Key');
     const body = {
         model: settings.model || DEFAULT_TTS_MODEL,
@@ -355,9 +356,6 @@ function setupUploadHandlers() {
                 if (!name) throw new Error('请填写音色名称');
                 if (!text) throw new Error('请填写参考文本');
                 if (!file) throw new Error('请选择参考音频文件');
-                if (!/^[a-zA-Z0-9_\-]+$/.test(name)) {
-                    throw new Error('音色名称仅支持字母数字下划线');
-                }
                 const body = new FormData();
                 body.append('name', name);
                 body.append('text', text);


### PR DESCRIPTION
### Motivation
- Provide a single, file-backed persistence layer so plugin settings (表情包、主题、头像、语音等) are stored in a local JSON file instead of only in `localStorage`. 
- Keep existing import/export behavior and ensure compatibility with current flat key-value exports while enabling a stable top-level schema for future extensions. 
- Improve resilience against missing/corrupt files and avoid in-process write races. 

### Description
- Add `setting/dataStore.js` implementing a unified data manager with `load_data`, `save_data`, `create_item`, `update_item`, `delete_item`, `get_item`, `list_items`, `exportSnapshot` and `importSnapshot`, plus `createStorageAdapter` for backwards compatibility. 
- Persist to `carrot-input-panel-settings.json` via the browser File System Access/OPFS API when available, with automatic file creation, schema (`version`/`updatedAt`/`records`) and corruption fallback to `localStorage`. 
- Use a serialized `saveQueue` to sequence writes and sync managed keys into `localStorage` to preserve existing runtime behavior and compatibility. 
- Wire the store into `script.js` to initialize on startup and provide `settingsStorage` adapter to settings modules, and update `setting/sync.js` to export/import the new snapshot format while still supporting the legacy flat key-value format. 

### Testing
- Ran `node --check script.js` and it completed successfully. 
- Ran `node --check setting/sync.js` and it completed successfully. 
- Ran `node --check setting/dataStore.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b14756ae788322be057988303411ae)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new persistence layer that writes plugin settings to a server-managed JSON file via new Express endpoints, changing how settings are read/written and synced. Risk is moderate due to new backend file I/O and async save/restore paths, but includes localStorage fallback and schema normalization.
> 
> **Overview**
> Introduces an optional **file-backed settings datastore** for the Carrot/SillyTavern extension, persisting managed settings keys into a versioned `settings.json` (`version`/`updatedAt`/`records`) instead of relying solely on `localStorage`.
> 
> `script.js` now attempts to initialize `setting/dataStore.js` at startup and passes a `settingsStorage` adapter into the various settings modules; sticker save/load is also switched to use this adapter. `setting/sync.js` is updated to export/import the new snapshot format (while still accepting legacy flat key/value JSON) and to write through the datastore when a filename is configured.
> 
> Adds `server.js` (Express router) providing `GET`/`PUT` endpoints to read/create/overwrite the settings file with filename sanitization and corruption fallback, and updates the README with setup instructions. Also tweaks TTS endpoint normalization and relaxes validation on uploaded voice names in `setting/voice/index.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1d418d9c1acc8b28e718b7e6d66ee9952c991a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->